### PR TITLE
fix: mount ssh via DOCKER_BUILDKIT

### DIFF
--- a/.hourglass/scripts/buildContainer.sh
+++ b/.hourglass/scripts/buildContainer.sh
@@ -9,13 +9,7 @@ if [[ ! -z "$registry" ]]; then
     image="$registry/$image"
 fi
 
-# TODO(seanmcgary): remove this janky hack once the repo is public
-mkdir -p ./.hourglass/.docker-build-tmp
-cp -R ~/.ssh ./.hourglass/.docker-build-tmp
-
-# check if ~/.gitconfig exists
-if [[ -f ~/.gitconfig ]]; then
-    cp ~/.gitconfig ./.hourglass/.docker-build-tmp/
-fi
-
-docker build --progress=plain -t "${image}:${tag}" .
+DOCKER_BUILDKIT=1 docker build \
+    --ssh default \
+    --progress=plain \
+    -t "${image}:${tag}" .


### PR DESCRIPTION
This PR refactors the Docker build to use BuildKit SSH forwarding for pulling private Go modules, removing the previous .ssh copy hack with a setup that leverages the local ssh-agent.