### PR TITLE
fix: only use host.docker.internal when resolvable

### DIFF
--- a/.devkit/scripts/getOperatorRegistrationMetadata
+++ b/.devkit/scripts/getOperatorRegistrationMetadata
@@ -42,16 +42,12 @@ if [ "$RPC_URL" == "null" ] || [ -z "$RPC_URL" ]; then
     exit 1
 fi
 
-# Test if host.docker.internal resolves
-if getent hosts host.docker.internal >/dev/null; then
-    # Replace localhost with host.docker.internal for Docker networking
-    DOCKER_RPC_URL=$(echo "$RPC_URL" \
-        | sed 's/localhost/host.docker.internal/g' \
-        | sed 's/127.0.0.1/host.docker.internal/g')
-else
-    # When not available use localhost directly
-    DOCKER_RPC_URL="$RPC_URL"
-fi
+# Use DOCKER_HOST from env if provided
+DOCKER_HOST=${DOCKER_HOST:-"host.docker.internal"}
+
+# Replace localhost with DOCKER_HOST for Docker networking
+DOCKER_RPC_URL=$(echo "$RPC_URL" \
+  | sed "s/localhost/${DOCKER_HOST}/g; s/127\.0\.0\.1/${DOCKER_HOST}/g")
 
 # Extract TaskAVSRegistrar contract address from deployed contracts (if available)
 TASK_AVS_REGISTRAR=$(echo "$CONTEXT" | jq -r '.context.deployed_contracts[] | select(.name=="taskAVSRegistrar") | .address')


### PR DESCRIPTION
This PR replaces `localhost` with a defaulted `DOCKER_HOST` so that we can unblock CI/linux users.