### PR TITLE
fix: use --network=host on bls-helper docker run

### DIFF
--- a/.devkit/scripts/getOperatorRegistrationMetadata
+++ b/.devkit/scripts/getOperatorRegistrationMetadata
@@ -42,16 +42,16 @@ if [ "$RPC_URL" == "null" ] || [ -z "$RPC_URL" ]; then
     exit 1
 fi
 
-# Detect OS and default DOCKER_HOST when not provided
+# Detect OS and default DOCKERS_HOST when not provided
 if [[ "$(uname)" == "Linux" ]]; then
-  DOCKER_HOST=${DOCKER_HOST:-localhost}
+  DOCKERS_HOST=${DOCKERS_HOST:-localhost}
 else
-  DOCKER_HOST=${DOCKER_HOST:-host.docker.internal}
+  DOCKERS_HOST=${DOCKERS_HOST:-host.docker.internal}
 fi
 
 # Replace localhost/127.0.0.1 in RPC_URL with docker equivalent for environment
 DOCKER_RPC_URL=$(echo "$RPC_URL" \
-  | sed "s/localhost/${DOCKER_HOST}/g; s/127\.0\.0\.1/${DOCKER_HOST}/g")
+  | sed "s/localhost/${DOCKERS_HOST}/g; s/127\.0\.0\.1/${DOCKERS_HOST}/g")
 
 # Extract TaskAVSRegistrar contract address from deployed contracts (if available)
 TASK_AVS_REGISTRAR=$(echo "$CONTEXT" | jq -r '.context.deployed_contracts[] | select(.name=="taskAVSRegistrar") | .address')


### PR DESCRIPTION
This PR adds `--network=host` to the `bls-helper` docker run command to make sure its able to communicate with docker in linux environments, and renames the `DOCKER_HOST` env var to avoid conflict with docker internals.