### PR TITLE
fix: use ensureDockerHost over rpc_urls and save to .yaml files

### DIFF
--- a/.devkit/scripts/getOperatorRegistrationMetadata
+++ b/.devkit/scripts/getOperatorRegistrationMetadata
@@ -42,16 +42,8 @@ if [ "$RPC_URL" == "null" ] || [ -z "$RPC_URL" ]; then
     exit 1
 fi
 
-# Detect OS and default DOCKERS_HOST when not provided
-if [[ "$(uname)" == "Linux" ]]; then
-  DOCKERS_HOST=${DOCKERS_HOST:-localhost}
-else
-  DOCKERS_HOST=${DOCKERS_HOST:-host.docker.internal}
-fi
-
 # Replace localhost/127.0.0.1 in RPC_URL with docker equivalent for environment
-DOCKER_RPC_URL=$(echo "$RPC_URL" \
-  | sed "s/localhost/${DOCKERS_HOST}/g; s/127\.0\.0\.1/${DOCKERS_HOST}/g")
+DOCKER_RPC_URL=$(ensureDockerHost "$RPC_URL")
 
 # Extract TaskAVSRegistrar contract address from deployed contracts (if available)
 TASK_AVS_REGISTRAR=$(echo "$CONTEXT" | jq -r '.context.deployed_contracts[] | select(.name=="taskAVSRegistrar") | .address')

--- a/.devkit/scripts/helpers/helpers.sh
+++ b/.devkit/scripts/helpers/helpers.sh
@@ -54,3 +54,20 @@ function ensureGomplate() {
         exit 1
     fi
 }
+
+# Pass in RPC_URL ($1)
+function ensureDockerHost() {
+    # Detect OS and default DOCKERS_HOST when not provided
+    if [[ "$(uname)" == "Linux" ]]; then
+        DOCKERS_HOST=${DOCKERS_HOST:-localhost}
+    else
+        DOCKERS_HOST=${DOCKERS_HOST:-host.docker.internal}
+    fi
+
+    # Replace localhost/127.0.0.1 in RPC_URL with docker equivalent for environment
+    DOCKER_RPC_URL=$(echo "$1" \
+        | sed "s/localhost/${DOCKERS_HOST}/g; s/127\.0\.0\.1/${DOCKERS_HOST}/g")
+
+    # Return properly formed RPC url
+    echo $DOCKER_RPC_URL
+}

--- a/.devkit/scripts/helpers/helpers.sh
+++ b/.devkit/scripts/helpers/helpers.sh
@@ -65,8 +65,11 @@ function ensureDockerHost() {
     fi
 
     # Replace localhost/127.0.0.1 in RPC_URL with docker equivalent for environment
-    DOCKER_RPC_URL=$(echo "$1" \
-        | sed "s/localhost/${DOCKERS_HOST}/g; s/127\.0\.0\.1/${DOCKERS_HOST}/g")
+    DOCKER_RPC_URL=$(
+    echo "$1" |
+    sed -E \
+        -e "s#(https?://)(localhost|127\.0\.0\.1)(:[0-9]+)?#\1${DOCKERS_HOST}\3#g"
+    )
 
     # Return properly formed RPC url
     echo $DOCKER_RPC_URL

--- a/.devkit/scripts/run
+++ b/.devkit/scripts/run
@@ -47,6 +47,16 @@ function loadBlsKeysForAllOperators() {
 
 loadBlsKeysForAllOperators
 
+# construct rpc_urls for environment
+L1_RPC_URL=$(echo $CONTEXT | jq -r '.context.chains.l1.rpc_url')
+L1_DOCKER_RPC_URL=$(ensureDockerHost "$L1_RPC_URL")
+L2_RPC_URL=$(echo $CONTEXT | jq -r '.context.chains.l2.rpc_url')
+L2_DOCKER_RPC_URL=$(ensureDockerHost "$L2_RPC_URL")
+
+# return rpc_urls to context
+CONTEXT=$(echo $CONTEXT | jq --arg url "$L1_DOCKER_RPC_URL" '.context.chains.l1.rpc_url = $url')
+CONTEXT=$(echo $CONTEXT | jq --arg url "$L2_DOCKER_RPC_URL" '.context.chains.l2.rpc_url = $url')
+
 # set aggregator and executor
 CONTEXT=$(echo $CONTEXT | jq --argjson contextConfig "$contextConfig" '.aggregator = $contextConfig.aggregator')
 CONTEXT=$(echo $CONTEXT | jq --argjson contextConfig "$contextConfig" '.executor = $contextConfig.executor')

--- a/.hourglass/config/aggregator-template.yaml
+++ b/.hourglass/config/aggregator-template.yaml
@@ -35,7 +35,7 @@ chains:
   - name: "ethereum"
     network: "mainnet"
     chainId: {{ (ds "ctx").context.chains.l1.chain_id }}
-    rpcUrl: "http://host.docker.internal:8545"
+    rpcUrl: "{{ (ds "ctx").context.chains.l1.rpc_url }}"
     pollIntervalSeconds: 2
 
 avss:

--- a/.hourglass/config/executor-template.yaml
+++ b/.hourglass/config/executor-template.yaml
@@ -26,7 +26,7 @@ operator:
   {{- end }}
 l1Chain:
   chainId: "{{ (ds "ctx").context.chains.l1.chain_id }}"
-  rpcUrl: "http://host.docker.internal:8545"
+  rpcUrl: "{{ (ds "ctx").context.chains.l1.rpc_url }}"
 avsPerformers:
   - image:
       repository: "my-avs"


### PR DESCRIPTION
This PR ensures we're storing the correct RPC url into `aggregator.yaml` and `executor.yaml` to allow the `rpc_url` (and port) to be set from `context.yaml`. We also ensure the host is passed correctly in the given environment. 

To test:

- Create a new project and cd in to it
- Call `devkit avs template upgrade --version fix/internal-docker-rpcs`
- Call `devkit avs build`
- Call `devkit avs start devnet --port 7545`
