### PR TITLE
docs: enhance code comments and populate test case

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -10,10 +10,12 @@ import (
 	"go.uber.org/zap"
 )
 
-// This offchain binary is run by Performer Operators.
-// It is responsible for ingesting tasks submitted by users to the TaskMailbox.
-// The Aggregator forwards onchain tasks to Performers.
-// Performers execute the task, sign the result, and send it back to the Aggregator.
+// This offchain binary is run by Operators running the Hourglass Executor. It contains
+// the business logic of the AVS and performs worked based on the tasked sent to it.
+// The Hourglass Aggregator ingests tasks from the TaskMailbox and distributes work
+// to Executors configured to run the AVS Performer. Performers execute the work and
+// return the result to the Executor where the result is signed and return to the
+// Aggregator to place in the outbox once the signing threshold is met.
 
 type TaskWorker struct {
 	logger *zap.Logger

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -12,8 +12,8 @@ import (
 
 // This offchain binary is run by Performer Operators.
 // It is responsible for ingesting tasks submitted by users to the TaskMailbox.
-// The aggregator forwards onchain tasks to Performers.
-// Performers execute the task, sign the result, and send it back to the aggregator.
+// The Aggregator forwards onchain tasks to Performers.
+// Performers execute the task, sign the result, and send it back to the Aggregator.
 
 type TaskWorker struct {
 	logger *zap.Logger

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -3,11 +3,17 @@ package main
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/Layr-Labs/hourglass-monorepo/ponos/pkg/performer/server"
 	performerV1 "github.com/Layr-Labs/protocol-apis/gen/protos/eigenlayer/hourglass/v1/performer"
 	"go.uber.org/zap"
-	"time"
 )
+
+// This offchain binary is run by Performer Operators.
+// It is responsible for ingesting tasks submitted by users to the TaskMailbox.
+// The aggregator forwards onchain tasks to Performers.
+// Performers execute the task, sign the result, and send it back to the aggregator.
 
 type TaskWorker struct {
 	logger *zap.Logger
@@ -23,9 +29,13 @@ func (tw *TaskWorker) ValidateTask(t *performerV1.TaskRequest) error {
 	tw.logger.Sugar().Infow("Validating task",
 		zap.Any("task", t),
 	)
+
 	// ------------------------------------------------------------------------
 	// Implement your AVS task validation logic here
 	// ------------------------------------------------------------------------
+	// This is where the Perfomer will validate the task request data.
+	// E.g. the Perfomer may validate that the request params are well formed and adhere to a schema.
+
 	return nil
 }
 
@@ -33,10 +43,12 @@ func (tw *TaskWorker) HandleTask(t *performerV1.TaskRequest) (*performerV1.TaskR
 	tw.logger.Sugar().Infow("Handling task",
 		zap.Any("task", t),
 	)
-	
+
 	// ------------------------------------------------------------------------
 	// Implement your AVS logic here
 	// ------------------------------------------------------------------------
+	// This is where the Performer will do the work and provide compute.
+	// E.g. the Perfomer could call an external API, a local service or a script.
 
 	var resultBytes []byte
 	return &performerV1.TaskResponse{

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -2,10 +2,38 @@ package main
 
 import (
 	"testing"
+
+	performerV1 "github.com/Layr-Labs/protocol-apis/gen/protos/eigenlayer/hourglass/v1/performer"
+	"go.uber.org/zap"
 )
 
 func Test_TaskRequestPayload(t *testing.T) {
 	// ------------------------------------------------------------------------
 	// Write your test cases here
 	// ------------------------------------------------------------------------
+
+	logger, err := zap.NewDevelopment()
+	if err != nil {
+		t.Errorf("Failed to create logger: %v", err)
+	}
+
+	taskWorker := NewTaskWorker(logger)
+
+	taskRequest := &performerV1.TaskRequest{
+		TaskId:   []byte("test-task-id"),
+		Payload:  []byte("test-data"),
+		Metadata: []byte("test-metadata"),
+	}
+
+	err = taskWorker.ValidateTask(taskRequest)
+	if err != nil {
+		t.Errorf("ValidateTask failed: %v", err)
+	}
+
+	resp, err := taskWorker.HandleTask(taskRequest)
+	if err != nil {
+		t.Errorf("HandleTask failed: %v", err)
+	}
+
+	t.Logf("Response: %v", resp)
 }


### PR DESCRIPTION
This PR enhances the comments for the Performer binary and populates the example test case to help guide developers when vendoring the template with `avs-create`