### PR TITLE
add makefile

### DIFF
--- a/contracts/Makefile
+++ b/contracts/Makefile
@@ -1,0 +1,7 @@
+create-task:
+	cast send $(AVS_ADDRESS) \
+	  "submitTask(uint32,bytes)" \
+	  $(EXECUTOR_OPERATOR_SET_ID) $(PAYLOAD) \
+	  --private-key $(PRIVATE_KEY_APP) \
+	  --rpc-url $(RPC_URL) \
+	  --legacy


### PR DESCRIPTION
The current DevKit template scaffolds an AVS project with a call script that invokes:
make create-task

[Readme instruction 6](https://github.com/Layr-Labs/devkit-cli?tab=readme-ov-file#6%EF%B8%8F%E2%83%A3-simulate-task-execution-devkit-avs-call) call fails with following error

```
make: *** No rule to make target 'create-task'.  Stop.
call failed: script .devkit/scripts/call exited with code 2
```

Adding the makefile succeeds the call 

<img width="864" alt="image" src="https://github.com/user-attachments/assets/8f9c759b-62d2-4af3-85d6-7802cfe1f582" />
