### PR TITLE
fix: install docker and yq from binary for linux systems

### DIFF
--- a/.devkit/scripts/helpers/helpers.sh
+++ b/.devkit/scripts/helpers/helpers.sh
@@ -59,7 +59,8 @@ function ensureGomplate() {
 function ensureDockerHost() {
     # Detect OS and default DOCKERS_HOST when not provided
     if [[ "$(uname)" == "Linux" ]]; then
-        DOCKERS_HOST=${DOCKERS_HOST:-172.17.0.1}
+        # Lookup the host using iproute
+        DOCKERS_HOST=${DOCKERS_HOST:-$(ip addr show docker0 | awk '/inet /{print $2}' | cut -d/ -f1)}
     else
         DOCKERS_HOST=${DOCKERS_HOST:-host.docker.internal}
     fi

--- a/.devkit/scripts/init
+++ b/.devkit/scripts/init
@@ -49,19 +49,44 @@ fi
 
 log_info "Detected platform: $PLATFORM $([ "$PLATFORM" == "linux" ] && echo "($LINUX_FLAVOR)")"
 
+inpath() {
+    echo $PATH | tr ':' '\n' | grep -qx "$1" && echo "$1 is in PATH" || echo "$1 is NOT in PATH"
+}
+
 add_to_path() {
-    local dir="$1"
-    local line="export PATH=\"\$PATH:$dir\""
-    for file in ~/.bashrc ~/.bash_profile; do
-        [[ -f $file ]] || continue
-        # append only if not already present
-        if ! grep -Fxq "$line" "$file"; then
-            echo "$line" >>"$file"
-        fi
-        # reload it
-        # shellcheck source=/dev/null
-        source "$file"
-    done
+  local dir="$1"
+  local line="export PATH=\"\$PATH:$dir\""
+  local shell_name rc_files file status
+
+  # detect current shell
+  if [[ -n "$ZSH_NAME" ]]; then
+    shell_name="zsh"
+  elif [[ -n "$BASH_VERSION" ]]; then
+    shell_name="bash"
+  else
+    shell_name="${SHELL##*/}"
+  fi
+
+  # choose rc files based on shell
+  if [[ "$shell_name" == "zsh" ]]; then
+    rc_files=(~/.zshrc ~/.zprofile)
+  else
+    rc_files=(~/.bashrc ~/.bash_profile)
+  fi
+
+  # check if "$dir" is already in PATH
+  status="$(inpath "$dir")"
+  if [[ "$status" == "$dir is in PATH" ]]; then
+    return
+  fi
+
+  # append export line to each existing rc file and reload it
+  for file in "${rc_files[@]}"; do
+    [[ -f "$file" ]] || continue
+    echo "$line" >>"$file"
+    # shellcheck source=/dev/null
+    source "$file"
+  done
 }
 
 # Check and install Homebrew on macOS
@@ -70,8 +95,8 @@ install_homebrew() {
         log_info "Installing Homebrew..."
         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
         # Add Homebrew to PATH for the current session
-        if [[ -d "/opt/homebrew/bin" ]]; then
-            export PATH="/opt/homebrew/bin:$PATH" # Apple Silicon
+        if [[ -d "$HOMEBREW_PREFIX/bin" ]]; then
+            export PATH="$HOMEBREW_PREFIX/bin:$PATH" # Apple Silicon
         elif [[ -d "/usr/local/bin" ]]; then
             export PATH="/usr/local/bin:$PATH" # Intel
         fi
@@ -157,7 +182,7 @@ install_docker_macos() {
     if ! command -v docker >/dev/null; then
         log_info "Installing Docker Desktop via Homebrew..."
         brew install --cask docker
-        log_info "Please open Docker.app to finish setup"
+        open /Applications/Docker.app
     else
         log_info "Docker Desktop already installed"
     fi

--- a/.devkit/scripts/init
+++ b/.devkit/scripts/init
@@ -3,29 +3,29 @@ set -e
 
 # Set sudo for non-root user
 if [ "$EUID" -eq 0 ]; then
-  SUDO=""
+    SUDO=""
 else
-  SUDO="sudo"
+    SUDO="sudo"
 fi
 
 # Function to log info messages
 log_info() {
-  printf '\033[0;34m[INFO]\033[0m %s\n' "$*" >&2
+    printf '\033[0;34m[INFO]\033[0m %s\n' "$*" >&2
 }
 
 # Function to log success messages
 log_success() {
-  printf '\033[0;32m[SUCCESS]\033[0m %s\n' "$*" >&2
+    printf '\033[0;32m[SUCCESS]\033[0m %s\n' "$*" >&2
 }
 
 # Function to log warning messages
 log_warning() {
-  printf '\033[0;33m[WARNING]\033[0m %s\n' "$*" >&2
+    printf '\033[0;33m[WARNING]\033[0m %s\n' "$*" >&2
 }
 
 # Function to log error messages
 log_error() {
-  printf '\033[0;31m[ERROR]\033[0m %s\n' "$*" >&2
+    printf '\033[0;31m[ERROR]\033[0m %s\n' "$*" >&2
 }
 
 # Check if we're running on macOS
@@ -50,18 +50,18 @@ fi
 log_info "Detected platform: $PLATFORM $([ "$PLATFORM" == "linux" ] && echo "($LINUX_FLAVOR)")"
 
 add_to_path() {
-  local dir="$1"
-  local line="export PATH=\"\$PATH:$dir\""
-  for file in ~/.bashrc ~/.bash_profile; do
-    [[ -f $file ]] || continue
-    # append only if not already present
-    if ! grep -Fxq "$line" "$file"; then
-      echo "$line" >> "$file"
-    fi
-    # reload it
-    # shellcheck source=/dev/null
-    source "$file"
-  done
+    local dir="$1"
+    local line="export PATH=\"\$PATH:$dir\""
+    for file in ~/.bashrc ~/.bash_profile; do
+        [[ -f $file ]] || continue
+        # append only if not already present
+        if ! grep -Fxq "$line" "$file"; then
+            echo "$line" >>"$file"
+        fi
+        # reload it
+        # shellcheck source=/dev/null
+        source "$file"
+    done
 }
 
 # Check and install Homebrew on macOS
@@ -71,9 +71,9 @@ install_homebrew() {
         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
         # Add Homebrew to PATH for the current session
         if [[ -d "/opt/homebrew/bin" ]]; then
-            export PATH="/opt/homebrew/bin:$PATH"  # Apple Silicon
+            export PATH="/opt/homebrew/bin:$PATH" # Apple Silicon
         elif [[ -d "/usr/local/bin" ]]; then
-            export PATH="/usr/local/bin:$PATH"  # Intel
+            export PATH="/usr/local/bin:$PATH" # Intel
         fi
         log_success "Homebrew installed successfully"
     else
@@ -85,7 +85,7 @@ install_homebrew() {
 install_with_brew() {
     local package=$1
     local command=${2:-$1}
-    
+
     if ! command -v "$command" >/dev/null 2>&1; then
         log_info "Installing $package..."
         brew install "$package"
@@ -105,12 +105,12 @@ install_with_apt() {
         # update only once per session
         if [ -z "$APT_UPDATED" ]; then
             DEBIAN_FRONTEND=noninteractive APT_LISTCHANGES_FRONTEND=none \
-              $SUDO apt-get update -qq
+                $SUDO apt-get update -qq
             APT_UPDATED=1
         fi
         # install package quietly and non-interactively
         DEBIAN_FRONTEND=noninteractive APT_LISTCHANGES_FRONTEND=none \
-          $SUDO apt-get install -y -qq "$package"
+            $SUDO apt-get install -y -qq "$package"
         log_success "$package installed successfully"
     else
         log_info "$package already present"
@@ -121,7 +121,7 @@ install_with_apt() {
 install_with_yum() {
     local package=$1
     local command=${2:-$1}
-    
+
     if ! command -v "$command" >/dev/null 2>&1; then
         log_info "Installing $package..."
         # update only once per session
@@ -145,7 +145,7 @@ install_foundry() {
         foundryup
 
         add_to_path "$HOME/.foundry/bin"
-        
+
         log_success "Foundry installed successfully"
     else
         log_info "Foundry is already installed"
@@ -154,110 +154,117 @@ install_foundry() {
 
 # Install Docker for osx
 install_docker_macos() {
-  if ! command -v docker >/dev/null; then
-    log_info "Installing Docker Desktop via Homebrew..."
-    brew install --cask docker
-    log_info "Please open Docker.app to finish setup"
-  else
-    log_info "Docker Desktop already installed"
-  fi
+    if ! command -v docker >/dev/null; then
+        log_info "Installing Docker Desktop via Homebrew..."
+        brew install --cask docker
+        log_info "Please open Docker.app to finish setup"
+    else
+        log_info "Docker Desktop already installed"
+    fi
 }
 
 # Install Docker
 install_docker() {
-  if command -v docker >/dev/null; then
-    log_info "Docker already installed"
-    return
-  fi
+    if command -v docker >/dev/null; then
+        log_info "Docker already installed"
+        return
+    fi
 
-  case "$LINUX_FLAVOR" in
+    case "$LINUX_FLAVOR" in
     debian)
-      # avoid interactive prompts (tzdata, etc)
-      export DEBIAN_FRONTEND=noninteractive
-      export TZ=Etc/UTC
+        # avoid interactive prompts (tzdata, etc)
+        export DEBIAN_FRONTEND=noninteractive
+        export TZ=Etc/UTC
 
-      log_info "Installing Docker on Debian/Ubuntu..."
-      $SUDO apt-get update
-      $SUDO apt-get install -y \
-        ca-certificates \
-        curl \
-        gnupg \
-        lsb-release
+        log_info "Installing Docker on Debian/Ubuntu..."
+        $SUDO apt-get update
+        $SUDO apt-get install -y \
+            ca-certificates \
+            curl \
+            gnupg \
+            lsb-release
 
-      # preseed tzdata
-      echo "$TZ" > /etc/timezone
-      $SUDO apt-get install -y tzdata
-      $SUDO dpkg-reconfigure --frontend noninteractive tzdata
+        # preseed tzdata
+        echo "$TZ" >/etc/timezone
+        $SUDO apt-get install -y tzdata
+        $SUDO dpkg-reconfigure --frontend noninteractive tzdata
 
-      # Add Docker’s official GPG key
-      curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg \
-        | $SUDO gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+        # Add Docker’s official GPG key
+        curl -fsSL https://download.docker.com/linux/$(
+            . /etc/os-release
+            echo "$ID"
+        )/gpg |
+            $SUDO gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
 
-      # Set up the stable repo
-      echo \
-        "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] \
-        https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") \
-        $(lsb_release -cs) stable" \
-        | $SUDO tee /etc/apt/sources.list.d/docker.list > /dev/null
-      $SUDO apt-get update
-      $SUDO apt-get install -y docker-ce docker-ce-cli containerd.io
-      ;;
+        # Set up the stable repo
+        echo \
+            "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] \
+        https://download.docker.com/linux/$(
+                . /etc/os-release
+                echo "$ID"
+            ) \
+        $(lsb_release -cs) stable" |
+            $SUDO tee /etc/apt/sources.list.d/docker.list >/dev/null
+        $SUDO apt-get update
+        $SUDO apt-get install -y docker-ce docker-ce-cli containerd.io
+        ;;
 
     rhel)
-      log_info "Installing Docker on RHEL/CentOS..."
-      $SUDO yum install -y yum-utils
-      $SUDO yum-config-manager \
-        --add-repo \
-        https://download.docker.com/linux/centos/docker-ce.repo
-      $SUDO yum install -y docker-ce docker-ce-cli containerd.io
-      ;;
+        log_info "Installing Docker on RHEL/CentOS..."
+        $SUDO yum install -y yum-utils
+        $SUDO yum-config-manager \
+            --add-repo \
+            https://download.docker.com/linux/centos/docker-ce.repo
+        $SUDO yum install -y docker-ce docker-ce-cli containerd.io
+        ;;
 
     *)
-      log_warning "Unsupported distro; please install Docker manually"
-      return
-      ;;
-  esac
+        log_warning "Unsupported distro; please install Docker manually"
+        return
+        ;;
+    esac
 
-  # Only enable+start via systemd if systemd is PID 1
-  if [ "$(ps -p 1 -o comm=)" = "systemd" ]; then
-    $SUDO systemctl enable --now docker
-    log_success "Docker enabled and started via systemd"
-  else
-    log_warning "Systemd not available - skipping service enable"
-    # Optionally start dockerd in background
-    if command -v dockerd &>/dev/null; then
-      log_info "Launching dockerd manually"
-      nohup dockerd >/var/log/dockerd.log 2>&1 & disown
-      log_success "dockerd running in background"
+    # Only enable+start via systemd if systemd is PID 1
+    if [ "$(ps -p 1 -o comm=)" = "systemd" ]; then
+        $SUDO systemctl enable --now docker
+        log_success "Docker enabled and started via systemd"
+    else
+        log_warning "Systemd not available - skipping service enable"
+        # Optionally start dockerd in background
+        if command -v dockerd &>/dev/null; then
+            log_info "Launching dockerd manually"
+            nohup dockerd >/var/log/dockerd.log 2>&1 &
+            disown
+            log_success "dockerd running in background"
+        fi
     fi
-  fi
 
-  log_success "docker installed successfully"
+    log_success "docker installed successfully"
 }
 
 # Function to install yq on Debian/Ubuntu from source
 install_yq_binary() {
-  if ! command -v yq &>/dev/null; then
-    VERSION=4.35.1
-    log_info "Installing yq v${VERSION}..."
+    if ! command -v yq &>/dev/null; then
+        VERSION=4.35.1
+        log_info "Installing yq v${VERSION}..."
 
-    # Detect current environment
-    ARCH=$(uname -m)
-    [[ $ARCH == x86_64 ]] && ARCH_SUFFIX=amd64 || ARCH_SUFFIX=arm64
+        # Detect current environment
+        ARCH=$(uname -m)
+        [[ $ARCH == x86_64 ]] && ARCH_SUFFIX=amd64 || ARCH_SUFFIX=arm64
 
-    # Install from github
-    curl -Lo /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/v${VERSION}/yq_linux_${ARCH_SUFFIX}"
+        # Install from github
+        curl -Lo /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/v${VERSION}/yq_linux_${ARCH_SUFFIX}"
 
-    # Ensure executable
-    $SUDO chmod +x /usr/local/bin/yq
+        # Ensure executable
+        $SUDO chmod +x /usr/local/bin/yq
 
-    # Add to bashrc/profile
-    add_to_path "/usr/local/bin"
+        # Add to bashrc/profile
+        add_to_path "/usr/local/bin"
 
-    log_success "yq installed successfully"
-  else
-    log_info "yq already present"
-  fi
+        log_success "yq installed successfully"
+    else
+        log_info "yq already present"
+    fi
 }
 
 # Function to install Go on macOS
@@ -269,11 +276,11 @@ install_go_macos() {
         brew install go@1.23.6 || brew upgrade go@1.23.6
 
         # Set up environment variables
-        echo 'export GOPATH=$HOME/go' >> ~/.bashrc
+        echo 'export GOPATH=$HOME/go' >>~/.bashrc
 
         # For systems that use .bash_profile instead of .bashrc
         if [[ -f ~/.bash_profile ]]; then
-            echo 'export GOPATH=$HOME/go' >> ~/.bash_profile
+            echo 'export GOPATH=$HOME/go' >>~/.bash_profile
         fi
 
         # Add to bashrc/profile
@@ -311,13 +318,13 @@ install_go_debian() {
         # Add to path to current session
         export GOPATH="$HOME/go"
         export PATH="/usr/local/go/bin:$GOPATH/bin:$PATH"
-        
+
         # Set up environment variables
-        echo 'export GOPATH=$HOME/go' >> ~/.bashrc
+        echo 'export GOPATH=$HOME/go' >>~/.bashrc
 
         # For systems that use .bash_profile instead of .bashrc
         if [[ -f ~/.bash_profile ]]; then
-            echo 'export GOPATH=$HOME/go' >> ~/.bash_profile
+            echo 'export GOPATH=$HOME/go' >>~/.bash_profile
         fi
 
         # Add to bashrc/profile
@@ -352,11 +359,11 @@ install_go_redhat() {
         rm go1.23.6.linux-amd64.tar.gz
 
         # Set up environment variables
-        echo 'export GOPATH=$HOME/go' >> ~/.bashrc
+        echo 'export GOPATH=$HOME/go' >>~/.bashrc
 
         # For systems that use .bash_profile instead of .bashrc
         if [[ -f ~/.bash_profile ]]; then
-            echo 'export GOPATH=$HOME/go' >> ~/.bash_profile
+            echo 'export GOPATH=$HOME/go' >>~/.bash_profile
         fi
 
         # Add to bashrc/profile
@@ -377,7 +384,6 @@ function install_gomplate_linux() {
         log_info "gomplate is already installed"
     fi
 }
-
 
 # Install dependencies based on platform
 if [[ "$PLATFORM" == "macos" ]]; then
@@ -455,7 +461,7 @@ fi
 
 rm -rf contracts/.git || true
 
-cat .devkit/templateGitignore >> .gitignore
+cat .devkit/templateGitignore >>.gitignore
 rm .devkit/templateGitignore
 
-log_info "Initialization complete. You can now run the other scripts in .devkit/scripts/" 
+log_info "Initialization complete. You can now run the other scripts in .devkit/scripts/"

--- a/.devkit/scripts/init
+++ b/.devkit/scripts/init
@@ -1,24 +1,31 @@
 #!/usr/bin/env bash
 set -e
 
+# Set sudo for non-root user
+if [ "$EUID" -eq 0 ]; then
+  SUDO=""
+else
+  SUDO="sudo"
+fi
+
 # Function to log info messages
 log_info() {
-    echo -e "\033[0;34m[INFO]\033[0m $@"
+  printf '\033[0;34m[INFO]\033[0m %s\n' "$*" >&2
 }
 
 # Function to log success messages
 log_success() {
-    echo -e "\033[0;32m[SUCCESS]\033[0m $@"
+  printf '\033[0;32m[SUCCESS]\033[0m %s\n' "$*" >&2
 }
 
 # Function to log warning messages
 log_warning() {
-    echo -e "\033[0;33m[WARNING]\033[0m $@"
+  printf '\033[0;33m[WARNING]\033[0m %s\n' "$*" >&2
 }
 
 # Function to log error messages
 log_error() {
-    echo -e "\033[0;31m[ERROR]\033[0m $@"
+  printf '\033[0;31m[ERROR]\033[0m %s\n' "$*" >&2
 }
 
 # Check if we're running on macOS
@@ -41,6 +48,21 @@ else
 fi
 
 log_info "Detected platform: $PLATFORM $([ "$PLATFORM" == "linux" ] && echo "($LINUX_FLAVOR)")"
+
+add_to_path() {
+  local dir="$1"
+  local line="export PATH=\"\$PATH:$dir\""
+  for file in ~/.bashrc ~/.bash_profile; do
+    [[ -f $file ]] || continue
+    # append only if not already present
+    if ! grep -Fxq "$line" "$file"; then
+      echo "$line" >> "$file"
+    fi
+    # reload it
+    # shellcheck source=/dev/null
+    source "$file"
+  done
+}
 
 # Check and install Homebrew on macOS
 install_homebrew() {
@@ -77,14 +99,21 @@ install_with_brew() {
 install_with_apt() {
     local package=$1
     local command=${2:-$1}
-    
+
     if ! command -v "$command" >/dev/null 2>&1; then
         log_info "Installing $package..."
-        sudo apt-get update
-        sudo apt-get install -y "$package"
+        # update only once per session
+        if [ -z "$APT_UPDATED" ]; then
+            DEBIAN_FRONTEND=noninteractive APT_LISTCHANGES_FRONTEND=none \
+              $SUDO apt-get update -qq
+            APT_UPDATED=1
+        fi
+        # install package quietly and non-interactively
+        DEBIAN_FRONTEND=noninteractive APT_LISTCHANGES_FRONTEND=none \
+          $SUDO apt-get install -y -qq "$package"
         log_success "$package installed successfully"
     else
-        log_info "$package is already installed"
+        log_info "$package already present"
     fi
 }
 
@@ -95,8 +124,12 @@ install_with_yum() {
     
     if ! command -v "$command" >/dev/null 2>&1; then
         log_info "Installing $package..."
-        sudo yum update -y
-        sudo yum install -y "$package"
+        # update only once per session
+        if [ -z "$YUM_UPDATED" ]; then
+            $SUDO yum update -y
+            YUM_UPDATED=1
+        fi
+        $SUDO yum install -y "$package"
         log_success "$package installed successfully"
     else
         log_info "$package is already installed"
@@ -110,22 +143,121 @@ install_foundry() {
         curl -L https://foundry.paradigm.xyz | bash
         export PATH="$PATH:$HOME/.foundry/bin"
         foundryup
+
+        add_to_path "$HOME/.foundry/bin"
+        
         log_success "Foundry installed successfully"
     else
         log_info "Foundry is already installed"
     fi
 }
 
+# Install Docker for osx
+install_docker_macos() {
+  if ! command -v docker >/dev/null; then
+    log_info "Installing Docker Desktop via Homebrew..."
+    brew install --cask docker
+    log_info "Please open Docker.app to finish setup"
+  else
+    log_info "Docker Desktop already installed"
+  fi
+}
+
 # Install Docker
 install_docker() {
-    if ! command -v docker >/dev/null 2>&1; then
-        log_info "Docker not found. Please install Docker manually:"
-        log_info "macOS: https://docs.docker.com/desktop/install/mac-install/"
-        log_info "Linux: https://docs.docker.com/engine/install/"
-        log_warning "Docker installation skipped (manual installation required)"
-    else
-        log_info "Docker is already installed"
+  if command -v docker >/dev/null; then
+    log_info "Docker already installed"
+    return
+  fi
+
+  case "$LINUX_FLAVOR" in
+    debian)
+      # avoid interactive prompts (tzdata, etc)
+      export DEBIAN_FRONTEND=noninteractive
+      export TZ=Etc/UTC
+
+      log_info "Installing Docker on Debian/Ubuntu..."
+      $SUDO apt-get update
+      $SUDO apt-get install -y \
+        ca-certificates \
+        curl \
+        gnupg \
+        lsb-release
+
+      # preseed tzdata
+      echo "$TZ" > /etc/timezone
+      $SUDO apt-get install -y tzdata
+      $SUDO dpkg-reconfigure --frontend noninteractive tzdata
+
+      # Add Docker’s official GPG key
+      curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg \
+        | $SUDO gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+
+      # Set up the stable repo
+      echo \
+        "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] \
+        https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") \
+        $(lsb_release -cs) stable" \
+        | $SUDO tee /etc/apt/sources.list.d/docker.list > /dev/null
+      $SUDO apt-get update
+      $SUDO apt-get install -y docker-ce docker-ce-cli containerd.io
+      ;;
+
+    rhel)
+      log_info "Installing Docker on RHEL/CentOS..."
+      $SUDO yum install -y yum-utils
+      $SUDO yum-config-manager \
+        --add-repo \
+        https://download.docker.com/linux/centos/docker-ce.repo
+      $SUDO yum install -y docker-ce docker-ce-cli containerd.io
+      ;;
+
+    *)
+      log_warning "Unsupported distro; please install Docker manually"
+      return
+      ;;
+  esac
+
+  # Only enable+start via systemd if systemd is PID 1
+  if [ "$(ps -p 1 -o comm=)" = "systemd" ]; then
+    $SUDO systemctl enable --now docker
+    log_success "Docker enabled and started via systemd"
+  else
+    log_warning "Systemd not available - skipping service enable"
+    # Optionally start dockerd in background
+    if command -v dockerd &>/dev/null; then
+      log_info "Launching dockerd manually"
+      nohup dockerd >/var/log/dockerd.log 2>&1 & disown
+      log_success "dockerd running in background"
     fi
+  fi
+
+  log_success "docker installed successfully"
+}
+
+# Function to install yq on Debian/Ubuntu from source
+install_yq_binary() {
+  if ! command -v yq &>/dev/null; then
+    VERSION=4.35.1
+    log_info "Installing yq v${VERSION}..."
+
+    # Detect current environment
+    ARCH=$(uname -m)
+    [[ $ARCH == x86_64 ]] && ARCH_SUFFIX=amd64 || ARCH_SUFFIX=arm64
+
+    # Install from github
+    curl -Lo /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/v${VERSION}/yq_linux_${ARCH_SUFFIX}"
+
+    # Ensure executable
+    $SUDO chmod +x /usr/local/bin/yq
+
+    # Add to bashrc/profile
+    add_to_path "/usr/local/bin"
+
+    log_success "yq installed successfully"
+  else
+    log_info "yq already present"
+  fi
 }
 
 # Function to install Go on macOS
@@ -138,8 +270,16 @@ install_go_macos() {
 
         # Set up environment variables
         echo 'export GOPATH=$HOME/go' >> ~/.bashrc
-        echo 'export PATH=$PATH:/usr/local/go/bin:$GOPATH/bin' >> ~/.bashrc
-        source ~/.bashrc
+
+        # For systems that use .bash_profile instead of .bashrc
+        if [[ -f ~/.bash_profile ]]; then
+            echo 'export GOPATH=$HOME/go' >> ~/.bash_profile
+        fi
+
+        # Add to bashrc/profile
+        add_to_path "/usr/local/go/bin:$GOPATH/bin"
+
+        log_success "golang installed successfully"
     else
         log_info "golang is already installed."
     fi
@@ -151,52 +291,42 @@ install_go_debian() {
         log_info "Installing Go 1.23.6 on Debian/Ubuntu..."
 
         # Update package lists
-        sudo apt-get update
+        $SUDO apt-get update
 
         # Install dependencies
-        sudo apt-get install -y wget tar
+        $SUDO apt-get install -y wget tar
 
         # Download Go 1.23.6
         wget https://golang.org/dl/go1.23.6.linux-amd64.tar.gz
 
         # Remove any previous Go installation
-        sudo rm -rf /usr/local/go
+        $SUDO rm -rf /usr/local/go
 
         # Extract the archive
-        sudo tar -C /usr/local -xzf go1.23.6.linux-amd64.tar.gz
+        $SUDO tar -C /usr/local -xzf go1.23.6.linux-amd64.tar.gz
 
         # Clean up
         rm go1.23.6.linux-amd64.tar.gz
 
+        # Add to path to current session
+        export GOPATH="$HOME/go"
+        export PATH="/usr/local/go/bin:$GOPATH/bin:$PATH"
+        
         # Set up environment variables
         echo 'export GOPATH=$HOME/go' >> ~/.bashrc
-        echo 'export PATH=$PATH:/usr/local/go/bin:$GOPATH/bin' >> ~/.bashrc
-        source ~/.bashrc
+
+        # For systems that use .bash_profile instead of .bashrc
+        if [[ -f ~/.bash_profile ]]; then
+            echo 'export GOPATH=$HOME/go' >> ~/.bash_profile
+        fi
+
+        # Add to bashrc/profile
+        add_to_path "/usr/local/go/bin:$GOPATH/bin"
+
+        log_success "golang installed successfully"
     else
         log_info "golang is already installed."
     fi
-}
-
-# Function to install yq on Debian/Ubuntu from source
-install_yq_binary() {
-  if ! command -v yq &>/dev/null; then
-    VERSION=4.45.4
-    log_info "Installing yq v${VERSION}..."
-
-    # Detect current environment
-    ARCH=$(uname -m)
-    [[ $ARCH == x86_64 ]] && BIN=yq_linux_amd64 || BIN=yq_linux_arm64
-
-    # Install from github
-    curl -fsSL "https://github.com/mikefarah/yq/releases/download/v${VERSION}/yq_${BIN}" \
-      | sudo tee /usr/local/bin/yq > /dev/null
-
-    # Ensure executable
-    sudo chmod +x /usr/local/bin/yq
-    log_success "yq installed"
-  else
-    log_info "yq already present"
-  fi
 }
 
 install_go_redhat() {
@@ -204,34 +334,35 @@ install_go_redhat() {
         log_info "Installing Go 1.23.6 on CentOS/RHEL/Fedora..."
 
         # Update package lists
-        sudo yum -y update
+        $SUDO yum -y update
 
         # Install dependencies
-        sudo yum -y install wget tar
+        $SUDO yum -y install wget tar
 
         # Download Go 1.23.6
         wget https://golang.org/dl/go1.23.6.linux-amd64.tar.gz
 
         # Remove any previous Go installation
-        sudo rm -rf /usr/local/go
+        $SUDO rm -rf /usr/local/go
 
         # Extract the archive
-        sudo tar -C /usr/local -xzf go1.23.6.linux-amd64.tar.gz
+        $SUDO tar -C /usr/local -xzf go1.23.6.linux-amd64.tar.gz
 
         # Clean up
         rm go1.23.6.linux-amd64.tar.gz
 
         # Set up environment variables
         echo 'export GOPATH=$HOME/go' >> ~/.bashrc
-        echo 'export PATH=$PATH:/usr/local/go/bin:$GOPATH/bin' >> ~/.bashrc
-        source ~/.bashrc
 
         # For systems that use .bash_profile instead of .bashrc
         if [[ -f ~/.bash_profile ]]; then
             echo 'export GOPATH=$HOME/go' >> ~/.bash_profile
-            echo 'export PATH=$PATH:/usr/local/go/bin:$GOPATH/bin' >> ~/.bash_profile
-            source ~/.bash_profile
         fi
+
+        # Add to bashrc/profile
+        add_to_path "/usr/local/go/bin:$GOPATH/bin"
+
+        log_success "golang installed successfully"
     else
         log_info "golang is already installed."
     fi
@@ -258,12 +389,14 @@ if [[ "$PLATFORM" == "macos" ]]; then
     install_with_brew jq
     install_with_brew yq
     install_foundry
-    install_docker
     install_go_macos
+    install_docker_macos
 elif [[ "$PLATFORM" == "linux" ]]; then
     if [[ "$LINUX_FLAVOR" == "debian" ]]; then
+        install_with_apt apt-utils
         install_with_apt jq
         install_with_apt make
+        install_with_apt iproute2
         install_with_apt coreutils realpath
         install_go_debian
         install_gomplate_linux
@@ -273,7 +406,9 @@ elif [[ "$PLATFORM" == "linux" ]]; then
     elif [[ "$LINUX_FLAVOR" == "rhel" ]]; then
         install_with_yum jq
         install_with_yum make
+        install_with_yum iproute
         install_with_yum coreutils realpath
+        install_with_yum procps-ng
         install_go_redhat
         install_gomplate_linux
         install_yq_binary
@@ -284,6 +419,7 @@ elif [[ "$PLATFORM" == "linux" ]]; then
         log_warning "- jq"
         log_warning "- yq"
         log_warning "- make"
+        log_warning "- iproute"
         log_warning "- realpath (from coreutils)"
         log_warning "- forge (from Foundry)"
         log_warning "- docker"

--- a/.devkit/scripts/init
+++ b/.devkit/scripts/init
@@ -177,6 +177,28 @@ install_go_debian() {
     fi
 }
 
+# Function to install yq on Debian/Ubuntu from source
+install_yq_binary() {
+  if ! command -v yq &>/dev/null; then
+    VERSION=4.45.4
+    log_info "Installing yq v${VERSION}..."
+
+    # Detect current environment
+    ARCH=$(uname -m)
+    [[ $ARCH == x86_64 ]] && BIN=yq_linux_amd64 || BIN=yq_linux_arm64
+
+    # Install from github
+    curl -fsSL "https://github.com/mikefarah/yq/releases/download/v${VERSION}/yq_${BIN}" \
+      | sudo tee /usr/local/bin/yq > /dev/null
+
+    # Ensure executable
+    sudo chmod +x /usr/local/bin/yq
+    log_success "yq installed"
+  else
+    log_info "yq already present"
+  fi
+}
+
 install_go_redhat() {
     if ! command -v go >/dev/null 2>&1; then
         log_info "Installing Go 1.23.6 on CentOS/RHEL/Fedora..."
@@ -241,36 +263,20 @@ if [[ "$PLATFORM" == "macos" ]]; then
 elif [[ "$PLATFORM" == "linux" ]]; then
     if [[ "$LINUX_FLAVOR" == "debian" ]]; then
         install_with_apt jq
-        install_with_apt python3-pip pip3
         install_with_apt make
         install_with_apt coreutils realpath
         install_go_debian
         install_gomplate_linux
-        # Install yq via pip
-        if ! command -v yq >/dev/null 2>&1; then
-            log_info "Installing yq..."
-            pip3 install yq
-            log_success "yq installed successfully"
-        else
-            log_info "yq is already installed"
-        fi
+        install_yq_binary
         install_foundry
         install_docker
     elif [[ "$LINUX_FLAVOR" == "rhel" ]]; then
         install_with_yum jq
-        install_with_yum python3-pip pip3
         install_with_yum make
         install_with_yum coreutils realpath
         install_go_redhat
         install_gomplate_linux
-        # Install yq via pip
-        if ! command -v yq >/dev/null 2>&1; then
-            log_info "Installing yq..."
-            pip3 install yq
-            log_success "yq installed successfully"
-        else
-            log_info "yq is already installed"
-        fi
+        install_yq_binary
         install_foundry
         install_docker
     else

--- a/.hourglass/scripts/buildContainer.sh
+++ b/.hourglass/scripts/buildContainer.sh
@@ -10,6 +10,6 @@ if [[ ! -z "$registry" ]]; then
     image="$registry/$image"
 fi
 
-DOCKER_BUILDKIT=1 docker build \
+docker build \
     --progress=plain \
     -t "${image}:${tag}" .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,4 @@
-# syntax=docker/dockerfile:1.3
-
 FROM golang:1.23.6-bookworm AS build
-
-RUN apt-get update
 
 WORKDIR /build
 


### PR DESCRIPTION
This PR:

- extends the init script to install `docker` (in all envs if missing) and `yq` from binary
- fixes logging for all envs
- ensures we add new `dirs` to the `path` and `profile` (`bash`/`zsh`) in a consistent manner
- pulls the docker-host from `docker0` so it will work in `dind` envs
- removes remnant `buildkit` artefacts

To test, checkout this branch and run:

```
# Start a ubuntu container (arm64 - we can verify amd64 later in CI)
docker run --privileged -it --rm \
  -v "$PWD":/workdir \
  -w /workdir \
  --platform linux/arm64 \
  ubuntu:latest \
  bash

# These remain pre-reqs, we need these to perform the install & create
apt-get update && apt-get install curl git -y

# Install devkit
mkdir -p $HOME/bin && curl -sL https://s3.amazonaws.com/eigenlayer-devkit-releases/v0.0.8/devkit-linux-arm64-v0.0.8.tar.gz | tar xv -C "$HOME/bin"

# Add ~/bin to path
export PATH=$PATH:~/bin

# Create project from this branch/commit
devkit avs create --template-url="." --template-version="8a6dd70527f2cc72eeb166c2b56e7da1fb8094d2" my-hourglass-project ../

# Move to project
cd ../my-hourglass-project

# Reload any new shell settings
source ~/.bashrc

# Build the project
devkit avs build

# Set .env vars then start
printf 'L1_FORK_URL=".../"\nL2_FORK_URL=".../"\n' >> .env
devkit avs devnet start
```