### PR TITLE
fix: cast nightly warning

### DIFF
--- a/.devkit/scripts/getOperatorRegistrationMetadata
+++ b/.devkit/scripts/getOperatorRegistrationMetadata
@@ -95,6 +95,7 @@ process_operators() {
         fi
         
         # Use cast to ABI encode the socket string
+        # Disable nightly warnings for cast
         set +e
         local registration_payload_with_prefix=$(FOUNDRY_DISABLE_NIGHTLY_WARNING=1 cast abi-encode "f(string)" "$operator_socket" 2>&1)
         CAST_EXIT_CODE=$?

--- a/.devkit/scripts/getOperatorRegistrationMetadata
+++ b/.devkit/scripts/getOperatorRegistrationMetadata
@@ -96,7 +96,7 @@ process_operators() {
         
         # Use cast to ABI encode the socket string
         set +e
-        local registration_payload_with_prefix=$(cast abi-encode "f(string)" "$operator_socket" 2>&1)
+        local registration_payload_with_prefix=$(FOUNDRY_DISABLE_NIGHTLY_WARNING=1 cast abi-encode "f(string)" "$operator_socket" 2>&1)
         CAST_EXIT_CODE=$?
         set -e
         


### PR DESCRIPTION
**Motivation:**
The foundry nightly warning was appearing in the cast response. Disable that warning while making the call.