### PR TITLE
feat: release manager context 

### DIFF
--- a/.devkit/scripts/build
+++ b/.devkit/scripts/build
@@ -27,11 +27,10 @@ IMAGE_ID=$(docker inspect "$LOCAL_IMAGE_NAME" --format='{{.Id}}')
 log "Building contracts..."
 cd .devkit/contracts && forge clean && forge build -- --include ../../contracts/**/*.sol >&2
 
-# Set registry URL - use ghcr.io if REGISTRY is nil, otherwise use the specified registry
+# If empty , log it 
 if [ "$REGISTRY" == "null" ] || [ -z "$REGISTRY" ]; then
-    REGISTRY_URL="ghcr.io"
+    log "Registry Url empty in .hourglass/build.yaml.Passing empty registry url to context. Provide registry url explicitly while calling `devkit avs release publish`"
 else
-    REGISTRY_URL="${REGISTRY}"
 fi
 
 # Create and output the JSON structure
@@ -39,7 +38,7 @@ RESULT=$(jq -n \
     --arg component "performer" \
     --arg artifactId "$IMAGE_ID" \
     --arg digest "" \
-    --arg registry "$REGISTRY_URL" \
+    --arg registry "$$REGISTRY" \
     '{
         artifacts: {
             component: $component,

--- a/.devkit/scripts/build
+++ b/.devkit/scripts/build
@@ -20,9 +20,9 @@ VERSION=$(yq eval '.container.version' .hourglass/build.yaml)
 
 LOCAL_IMAGE_NAME="${IMAGE_NAME}:${VERSION}"
 
-# Get the container digest of the local image
-log "Getting container digest..."
-DIGEST=$(docker inspect "$LOCAL_IMAGE_NAME" --format='{{.Id}}')
+# Get the docker image id
+log "Getting docker image id..."
+IMAGE_ID=$(docker inspect "$LOCAL_IMAGE_NAME" --format='{{.Id}}')
 
 log "Building contracts..."
 cd .devkit/contracts && forge clean && forge build -- --include ../../contracts/**/*.sol >&2
@@ -36,11 +36,15 @@ fi
 
 # Create and output the JSON structure
 RESULT=$(jq -n \
-    --arg digest "$DIGEST" \
+    --arg component "performer" \
+    --arg artifactId "$IMAGE_ID" \
+    --arg digest "" \
     --arg registry "$REGISTRY_URL" \
     '{
         artifacts: {
-            image_digest: $digest,
+            component: $component,
+            artifactId: $artifactId,
+            digest: $digest,
             registry_url: $registry
         }
     }')
@@ -49,4 +53,4 @@ RESULT=$(jq -n \
 echo "$RESULT" | jq -c .
 
 log "Build completed successfully."
-log "Updated artifacts field in context with digest: $DIGEST"
+log "Updated artifacts field in context with image id: $IMAGE_ID"

--- a/.devkit/scripts/build
+++ b/.devkit/scripts/build
@@ -30,7 +30,9 @@ cd .devkit/contracts && forge clean && forge build -- --include ../../contracts/
 # If empty , log it 
 if [ "$REGISTRY" == "null" ] || [ -z "$REGISTRY" ]; then
     log "Registry Url empty in .hourglass/build.yaml.Passing empty registry url to context. Provide registry url explicitly while calling `devkit avs release publish`"
+    REGISTRY_URL=""
 else
+    REGISTRY_URL="${REGISTRY}"
 fi
 
 # Create and output the JSON structure
@@ -38,7 +40,7 @@ RESULT=$(jq -n \
     --arg component "performer" \
     --arg artifactId "$IMAGE_ID" \
     --arg digest "" \
-    --arg registry "$$REGISTRY" \
+    --arg registry "$REGISTRY_URL" \
     '{
         artifacts: {
             component: $component,

--- a/.devkit/scripts/build
+++ b/.devkit/scripts/build
@@ -18,14 +18,12 @@ IMAGE_NAME=$(yq eval '.container.image' .hourglass/build.yaml)
 REGISTRY=$(yq eval '.container.registry' .hourglass/build.yaml)
 VERSION=$(yq eval '.container.version' .hourglass/build.yaml)
 
-# For local build, we'll use the local image name
 LOCAL_IMAGE_NAME="${IMAGE_NAME}:${VERSION}"
 
 # Get the container digest of the local image
 log "Getting container digest..."
 DIGEST=$(docker inspect "$LOCAL_IMAGE_NAME" --format='{{.Id}}')
 
-log "Updated artifacts field in file with digest: $DIGEST"
 log "Building contracts..."
 cd .devkit/contracts && forge clean && forge build -- --include ../../contracts/**/*.sol >&2
 
@@ -51,3 +49,4 @@ RESULT=$(jq -n \
 echo "$RESULT" | jq -c .
 
 log "Build completed successfully."
+log "Updated artifacts field in context with digest: $DIGEST"

--- a/.devkit/scripts/build
+++ b/.devkit/scripts/build
@@ -13,7 +13,37 @@ ensureDocker
 log "Building AVS performer..."
 BUILD_CONTAINER=true ./.hourglass/scripts/build.sh >&2
 
+# Get container info from build.yaml
+buildParams=$(cat ../.hourglass/build.yaml)
+registry=$(echo "$buildParams" | yq -r '.container.registry')
+image=$(echo "$buildParams" | yq -r '.container.image')
+tag=$(echo "$buildParams" | yq -r '.container.version')
+
+# Construct full image name
+if [[ ! -z "$registry" ]]; then
+    full_image="${registry}/${image}:${tag}"
+else
+    full_image="${image}:${tag}"
+fi
+
+# Get the container digest
+log "Getting container digest..."
+DIGEST=$(docker inspect "$full_image" --format='{{.RepoDigests}}' | cut -d'@' -f2)
+
+# # Update the yaml file with the artifact digest
+# yaml_file="config/contexts/0.0.6.yaml"
+# if [ -f "$yaml_file" ]; then
+#     # Use yq to update the artifacts field
+#     yq e ".artifacts = \"$DIGEST\"" -i "$yaml_file"
+#     log "Updated artifacts field in $yaml_file with digest: $DIGEST"
+# else
+#     log "Error: $yaml_file not found"
+#     exit 1
+# fi
+
+log "Updated artifacts field in file with digest: $DIGEST"
+
 log "Building contracts..."
 cd .devkit/contracts && forge clean && forge build -- --include ../../contracts/**/*.sol >&2
 
-log "Build completed successfully." 
+log "Build completed successfully."

--- a/.devkit/scripts/build
+++ b/.devkit/scripts/build
@@ -18,22 +18,23 @@ IMAGE_NAME=$(yq eval '.container.image' .hourglass/build.yaml)
 REGISTRY=$(yq eval '.container.registry' .hourglass/build.yaml)
 VERSION=$(yq eval '.container.version' .hourglass/build.yaml)
 
-# Construct the full image name
-if [ -z "$REGISTRY" ]; then
-    FULL_IMAGE_NAME="ghcr.io/${IMAGE_NAME}:${VERSION}"
-    REGISTRY_URL="ghcr.io"
-else
-    FULL_IMAGE_NAME="${REGISTRY}/${IMAGE_NAME}:${VERSION}"
-    REGISTRY_URL="${REGISTRY}"
-fi
+# For local build, we'll use the local image name
+LOCAL_IMAGE_NAME="${IMAGE_NAME}:${VERSION}"
 
-# Get the container digest of the specific image
+# Get the container digest of the local image
 log "Getting container digest..."
-DIGEST=$(docker inspect "$FULL_IMAGE_NAME" --format='{{.Id}}')
+DIGEST=$(docker inspect "$LOCAL_IMAGE_NAME" --format='{{.Id}}')
 
 log "Updated artifacts field in file with digest: $DIGEST"
 log "Building contracts..."
 cd .devkit/contracts && forge clean && forge build -- --include ../../contracts/**/*.sol >&2
+
+# Set registry URL - use ghcr.io if REGISTRY is nil, otherwise use the specified registry
+if [ "$REGISTRY" == "null" ] || [ -z "$REGISTRY" ]; then
+    REGISTRY_URL="ghcr.io"
+else
+    REGISTRY_URL="${REGISTRY}"
+fi
 
 # Create and output the JSON structure
 RESULT=$(jq -n \

--- a/.devkit/scripts/build
+++ b/.devkit/scripts/build
@@ -13,37 +13,40 @@ ensureDocker
 log "Building AVS performer..."
 BUILD_CONTAINER=true ./.hourglass/scripts/build.sh >&2
 
-# Get container info from build.yaml
-buildParams=$(cat ../.hourglass/build.yaml)
-registry=$(echo "$buildParams" | yq -r '.container.registry')
-image=$(echo "$buildParams" | yq -r '.container.image')
-tag=$(echo "$buildParams" | yq -r '.container.version')
+# Get the image name from build.yaml
+IMAGE_NAME=$(yq eval '.container.image' .hourglass/build.yaml)
+REGISTRY=$(yq eval '.container.registry' .hourglass/build.yaml)
+VERSION=$(yq eval '.container.version' .hourglass/build.yaml)
 
-# Construct full image name
-if [[ ! -z "$registry" ]]; then
-    full_image="${registry}/${image}:${tag}"
+# Construct the full image name
+if [ -z "$REGISTRY" ]; then
+    FULL_IMAGE_NAME="ghcr.io/${IMAGE_NAME}:${VERSION}"
+    REGISTRY_URL="ghcr.io"
 else
-    full_image="${image}:${tag}"
+    FULL_IMAGE_NAME="${REGISTRY}/${IMAGE_NAME}:${VERSION}"
+    REGISTRY_URL="${REGISTRY}"
 fi
 
-# Get the container digest
+# Get the container digest of the specific image
 log "Getting container digest..."
-DIGEST=$(docker inspect "$full_image" --format='{{.RepoDigests}}' | cut -d'@' -f2)
-
-# # Update the yaml file with the artifact digest
-# yaml_file="config/contexts/0.0.6.yaml"
-# if [ -f "$yaml_file" ]; then
-#     # Use yq to update the artifacts field
-#     yq e ".artifacts = \"$DIGEST\"" -i "$yaml_file"
-#     log "Updated artifacts field in $yaml_file with digest: $DIGEST"
-# else
-#     log "Error: $yaml_file not found"
-#     exit 1
-# fi
+DIGEST=$(docker inspect "$FULL_IMAGE_NAME" --format='{{.Id}}')
 
 log "Updated artifacts field in file with digest: $DIGEST"
-
 log "Building contracts..."
 cd .devkit/contracts && forge clean && forge build -- --include ../../contracts/**/*.sol >&2
+
+# Create and output the JSON structure
+RESULT=$(jq -n \
+    --arg digest "$DIGEST" \
+    --arg registry "$REGISTRY_URL" \
+    '{
+        artifacts: {
+            image_digest: $digest,
+            registry_url: $registry
+        }
+    }')
+
+# Print the JSON to stdout
+echo "$RESULT" | jq -c .
 
 log "Build completed successfully."

--- a/.hourglass/build.yaml
+++ b/.hourglass/build.yaml
@@ -1,4 +1,4 @@
 container:
-  registry: "" # optional, defaults to ghcr
+  registry: "" # optional
   image: "my-avs"
   version: "latest"

--- a/.hourglass/build.yaml
+++ b/.hourglass/build.yaml
@@ -1,4 +1,4 @@
 container:
-  registry: "" # optional, defaults to dockerhub
+  registry: "" # optional, defaults to ghcr
   image: "my-avs"
   version: "latest"


### PR DESCRIPTION

- Pass empty digest, image id , component (performer for now) and registry url as a json stdout for devkit to consume.

- If registry url is empty , log this 





