### PR TITLE
fix: cp .devkit dir after upgrading

### DIFF
--- a/.devkit/scripts/upgrade
+++ b/.devkit/scripts/upgrade
@@ -41,7 +41,7 @@ done
 # Copy the rest of the template
 cp -rfv "${PROJECT_BASE_DIR}/.hourglass" $originalProjectDir
 cp -rfv "${PROJECT_BASE_DIR}/Dockerfile" $originalProjectDir
-cp -rfv "${PROJECT_BASE_DIR}/contracts" $originalProjectDir/contracts
+cp -rfv "${PROJECT_BASE_DIR}/contracts/" $originalProjectDir/contracts
 
 cd $PROJECT_BASE_DIR/.devkit/contracts
 git_repo=$(git config --get remote.origin.url | tr -d '\n')

--- a/.devkit/scripts/upgrade
+++ b/.devkit/scripts/upgrade
@@ -32,9 +32,10 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # Navigate to the parent directories to find .devkit
 PROJECT_BASE_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
 
+cp -rfv "${PROJECT_BASE_DIR}/.devkit" $originalProjectDir
 cp -rfv "${PROJECT_BASE_DIR}/.hourglass" $originalProjectDir
 cp -rfv "${PROJECT_BASE_DIR}/Dockerfile" $originalProjectDir
-cp -rfv "${PROJECT_BASE_DIR}/contracts/" $originalProjectDir/contracts/
+cp -rfv "${PROJECT_BASE_DIR}/contracts" $originalProjectDir/contracts
 
 cd $PROJECT_BASE_DIR/.devkit/contracts
 git_repo=$(git config --get remote.origin.url | tr -d '\n')

--- a/.devkit/scripts/upgrade
+++ b/.devkit/scripts/upgrade
@@ -32,7 +32,13 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # Navigate to the parent directories to find .devkit
 PROJECT_BASE_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
 
-cp -rfv "${PROJECT_BASE_DIR}/.devkit" $originalProjectDir
+# Copy everything from .devkit except for ./contracts
+for item in "${PROJECT_BASE_DIR}/.devkit/"*; do
+  [ "$(basename "$item")" = "contracts" ] && continue
+  cp -rfv "$item" "$originalProjectDir/.devkit/"
+done
+
+# Copy the rest of the template
 cp -rfv "${PROJECT_BASE_DIR}/.hourglass" $originalProjectDir
 cp -rfv "${PROJECT_BASE_DIR}/Dockerfile" $originalProjectDir
 cp -rfv "${PROJECT_BASE_DIR}/contracts" $originalProjectDir/contracts


### PR DESCRIPTION
Copy the `.devkit` dir following an upgrade to update `scripts` and ~~contracts~~ and any other `.devkit` artefacts OTHER than `./contracts`