### PR TITLE
fix: move back after cd'ing to .devkit/contracts

### DIFF
--- a/.devkit/scripts/build
+++ b/.devkit/scripts/build
@@ -11,6 +11,7 @@ ensureDocker
 
 log "Building contracts..."
 cd .devkit/contracts && forge clean && forge build -- --include ../../contracts/**/*.sol >&2
+cd -
 
 # Build the contracts and dependencies
 log "Building AVS performer..."

--- a/.devkit/scripts/build
+++ b/.devkit/scripts/build
@@ -10,8 +10,7 @@ ensureForge
 ensureDocker
 
 log "Building contracts..."
-cd .devkit/contracts && forge clean && forge build -- --include ../../contracts/**/*.sol >&2
-cd -
+cd .devkit/contracts && forge clean && forge build -- --include ../../contracts/**/*.sol && cd - >&2
 
 # Build the contracts and dependencies
 log "Building AVS performer..."

--- a/.devkit/scripts/build
+++ b/.devkit/scripts/build
@@ -10,7 +10,7 @@ ensureForge
 ensureDocker
 
 log "Building contracts..."
-cd .devkit/contracts && forge clean && forge build -- --include ../../contracts/**/*.sol && cd - >&2
+(cd .devkit/contracts && forge clean && forge build -- --include ../../contracts/**/*.sol && cd -) >&2
 
 # Build the contracts and dependencies
 log "Building AVS performer..."


### PR DESCRIPTION
Move back to prev directory after forge build