### PR TITLE
fix: fetch new ref before checkout

### DIFF
--- a/.devkit/scripts/upgrade
+++ b/.devkit/scripts/upgrade
@@ -87,7 +87,7 @@ if [[ ! -d "${originalProjectDir}/.git/modules/.devkit/contracts" ]]; then
 
     migratedContracts="1"
 
-    cd $originalProjectDir/.devkit/contracts && git checkout $git_ref && cd -
+    cd $originalProjectDir/.devkit/contracts && git fetch origin $git_ref && git checkout $git_ref && cd -
 
     # cleanup
     rm -rf $originalProjectDir/.oldcontracts || true


### PR DESCRIPTION
Make sure we fetch the upgraded contracts ref before checkout to avoid:

```
Updating contracts submodule to desired commit...
fatal: unable to read tree (78749d40126b6fea6977ca90859987c67c1db102)
2025/06/25 23:26:15 upgrade script execution failed: script /var/folders/ph/04f_sgvn4xz7ylqtd00m5tvh0000gn/T/devkit-template-upgrade-1013716629/.devkit/scripts/upgrade exited with code 128
```

This error can be reproduced by creating from `v0.0.12` and upgrading to `v0.0.13`