### PR TITLE
fix: check if .devkit/contracts is inline

### DIFF
--- a/.devkit/scripts/upgrade
+++ b/.devkit/scripts/upgrade
@@ -59,7 +59,7 @@ migratedContracts=""
 # anything in .devkit/contracts at all.
 # -----------------------------------------------------------------------------
 # first check to see if the .devkit/contracts directory is already a submodule
-if [[ ! -d "${originalProjectDir}/.git/modules/.devkit/contracts" ]]; then
+if ! git -C "$originalProjectDir" ls-tree -r HEAD | grep -q "160000.*\.devkit/contracts$"; then
     log "Contracts directory is not a submodule, making it one"
 
     cd $originalProjectDir


### PR DESCRIPTION
Currently, we're checking to see if `.devkit/contracts` is a submodule by checking if the `.git/modules/...` directory is present, if an upgrade is attempted and fails and the subsequent fix commit is removed to get back to a clean slate, then the `.git/modules/...` directory persists and the check fails essentially bricking the project. 

This PR uses git directly to check if the `.devkit/contracts` directory is registered as a submodule or not, to prevent any reliance on faulty/flaky state.