### PR TITLE
feat: adding curve type to devnet config and injecting ecdsa keystores

### DIFF
--- a/.devkit/scripts/getOperatorSets
+++ b/.devkit/scripts/getOperatorSets
@@ -52,6 +52,7 @@ log "Found $NUM_OPERATOR_SETS operator sets"
 # Transform the operator sets data to match the required format
 TRANSFORMED_SETS=$(echo "$OPERATOR_SETS" | jq -s 'map({
     operator_set_id: .id,
+    curve_type: .curve_type,
     strategies: .strategies | map({ strategy: . })
 })')
 

--- a/.devkit/scripts/run
+++ b/.devkit/scripts/run
@@ -37,7 +37,6 @@ function readOperatorBlsKeystore() {
 function loadBlsKeysForAllOperators() {
     local operatorCount=$(echo $CONTEXT | jq -r ".context.operators | length")
     for i in $(seq 0 $((operatorCount - 1))); do
-        local operatorAddress=$(echo $CONTEXT | jq -r ".context.operators[$i].address")
         local blsKeystorePath=$(echo $CONTEXT | jq -r ".context.operators[$i].bls_keystore_path")
         local blsKeyContents=$(echo $(readOperatorBlsKeystore $blsKeystorePath) | jq -c '.')
         # set the bls key contents in the context as a raw string
@@ -45,7 +44,24 @@ function loadBlsKeysForAllOperators() {
     done
 }
 
+# Load ECDSA keys from keystores
+function loadECDSAKeysForAllOperators() {
+    local operatorCount=$(echo $CONTEXT | jq -r ".context.operators | length")
+    for i in $(seq 0 $((operatorCount - 1))); do
+        local ecdsaKeystorePath=$(echo $CONTEXT | jq -r ".context.operators[$i].ecdsa_keystore_path // empty")
+        local ecdsaKeystorePassword=$(echo $CONTEXT | jq -r ".context.operators[$i].ecdsa_keystore_password // empty")
+        local ecdsaKey=$(echo $CONTEXT | jq -r ".context.operators[$i].ecdsa_key // empty")
+        
+        # If keystore path exists and is a file, add keystore contents to context
+        if [ "$ecdsaKeystorePath" != "null" ] && [ "$ecdsaKeystorePath" != "empty" ] && [ -f "$ecdsaKeystorePath" ]; then
+            local ecdsaKeystoreContents=$(cat "$ecdsaKeystorePath" | jq -c '.')
+            CONTEXT=$(echo $CONTEXT | jq --argjson ecdsaKeystoreContents "$ecdsaKeystoreContents" ".context.operators[$i].ecdsa_keystore_contents = \$ecdsaKeystoreContents")
+        fi
+    done
+}
+
 loadBlsKeysForAllOperators
+loadECDSAKeysForAllOperators
 
 # construct rpc_urls for environment
 L1_RPC_URL=$(echo $CONTEXT | jq -r '.context.chains.l1.rpc_url')

--- a/.hourglass/context/devnet.yaml
+++ b/.hourglass/context/devnet.yaml
@@ -1,7 +1,9 @@
 operatorSets:
   - id: 0
+    curve_type: "BN254"
     strategies: ["0x5C8b55722f421556a2AAfb7A3EA63d4c3e514312"] # StETH strategy
   - id: 1
+    curve_type: "BN254"
     strategies: ["0x5C8b55722f421556a2AAfb7A3EA63d4c3e514312"] # StETH strategy
 
 aggregator:


### PR DESCRIPTION
## Motivation
For ECDSA support, the template must specify which signing curve to use for each operator set. Eventually this should be configurable by the AVS developer, but hardcoded for now for sake of simplicity with devnet.