### PR TITLE
fix: create outputs directory and hourglass testnet context

### DIFF
--- a/.devkit/scripts/deployL1Contracts
+++ b/.devkit/scripts/deployL1Contracts
@@ -160,14 +160,23 @@ log "Starting L1 contract deployment using context for environment: $ENVIRONMENT
 # Change to contracts directory
 cd $contractsBasePath
 
+# Ensure outputs directory exists
+mkdir -p script/$ENVIRONMENT/output
+
 # Deploy AVS L1 contracts
 log "Deploying AVS L1 contracts..."
 PRIVATE_KEY_DEPLOYER="${PRIVATE_KEY_DEPLOYER}" make deploy-avs-l1-contracts RPC_URL="${L1_RPC_URL}" ENVIRONMENT="${ENVIRONMENT}" AVS_ADDRESS="${AVS_ADDRESS}" ALLOCATION_MANAGER_ADDRESS="${ALLOCATION_MANAGER_ADDRESS}" KEY_REGISTRAR_ADDRESS="${KEY_REGISTRAR_ADDRESS}" AGGREGATOR_OPERATOR_SET_ID="${AGGREGATOR_OPERATOR_SET_ID}" EXECUTOR_OPERATOR_SET_ID="${EXECUTOR_OPERATOR_SET_ID}" >&2
 
 log "L1 contract deployment completed successfully."
 
-# Sync nonce and sleep to prevent nonce conflicts
-sync_nonce_and_sleep "${PRIVATE_KEY_DEPLOYER}" "${L1_RPC_URL}" "deployer" 1
+# Ensure nonce is in sync
+if [ "$environment" == "devnet" ]; then
+    # Sync nonce and sleep to prevent nonce conflicts
+    sync_nonce_and_sleep "${PRIVATE_KEY_DEPLOYER}" "${L1_RPC_URL}" "deployer" 1
+else
+    # Sleep for a block on other networks
+    sleep 12
+fi
 
 # Deploy custom L1 contracts
 log "Deploying custom L1 contracts..."

--- a/.hourglass/context/testnet.yaml
+++ b/.hourglass/context/testnet.yaml
@@ -1,0 +1,22 @@
+operatorSets:
+  - id: 0
+    curve_type: "BN254"
+    strategies: ["0x8b29d91e67b013e855EaFe0ad704aC4Ab086a574"] # StETH strategy
+  - id: 1
+    curve_type: "BN254"
+    strategies: ["0x8b29d91e67b013e855EaFe0ad704aC4Ab086a574"] # StETH strategy
+
+aggregator:
+  operatorSetId: 0
+  operators:
+    - address: "0x90F79bf6EB2c4f870365E785982E1f101E93b906"
+      socket: "aggregator:9000"
+
+executor:
+  operatorSetId: 1
+  operators:
+    - address: "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65"
+      socket: "executor:9090"
+
+mailbox:
+  taskSla: 60


### PR DESCRIPTION
This PR ensures we are creating the `outputs` for the supplied context environment and defaults the `.hourglass/context/testnet.yaml` config (@0xrajath - should we have a generic way of constructing this or should we lock down the allowed contexts to `devnet`/`testnet`/`mainnet`?

Depends on: https://github.com/Layr-Labs/hourglass-contracts-template/pull/22