### PR TITLE
chore: clean up `.devkit/contracts`

### DIFF
--- a/.devkit/contracts/.env.example
+++ b/.devkit/contracts/.env.example
@@ -1,0 +1,15 @@
+# RPC URLs
+RPC_MAINNET="https://eth.llamarpc.com"
+RPC_HOLESKY="https://ethereum-holesky-rpc.publicnode.com"
+RPC_BASE="https://base-mainnet.g.alchemy.com/v2/..."
+
+# API key for Etherscan
+ETHERSCAN_API_KEY="API-KEY"
+
+# Private keys for the deployer and AVS
+# Anvil Private Key 0 (0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266)
+PRIVATE_KEY_DEPLOYER="PRIVATE-KEY"
+# Anvil Private Key 1 (0x70997970C51812dc3A010C7d01b50e0d17dc79C8)
+PRIVATE_KEY_AVS="PRIVATE-KEY"
+# Anvil Private Key 2 (0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC)
+PRIVATE_KEY_APP="PRIVATE-KEY"

--- a/.devkit/contracts/.gitignore
+++ b/.devkit/contracts/.gitignore
@@ -1,0 +1,15 @@
+# Compiler files
+cache/
+out/
+
+# Ignores development broadcast logs
+!/broadcast
+/broadcast/*/31337/
+/broadcast/**/dry-run/
+
+# Docs
+docs/
+
+# Dotenv file
+.env
+.idea

--- a/.devkit/contracts/.gitmodules
+++ b/.devkit/contracts/.gitmodules
@@ -1,0 +1,6 @@
+[submodule "lib/forge-std"]
+	path = lib/forge-std
+	url = https://github.com/foundry-rs/forge-std
+[submodule "lib/hourglass-monorepo"]
+	path = lib/hourglass-monorepo
+	url = https://github.com/Layr-Labs/hourglass-monorepo

--- a/.devkit/contracts/.gitmodules
+++ b/.devkit/contracts/.gitmodules
@@ -1,6 +1,0 @@
-[submodule "lib/forge-std"]
-	path = lib/forge-std
-	url = https://github.com/foundry-rs/forge-std
-[submodule "lib/hourglass-monorepo"]
-	path = lib/hourglass-monorepo
-	url = https://github.com/Layr-Labs/hourglass-monorepo

--- a/.devkit/contracts/Makefile
+++ b/.devkit/contracts/Makefile
@@ -1,0 +1,96 @@
+# Build the project
+.PHONY: build
+build:
+	forge clean
+	forge build
+
+# Test the project
+.PHONY: test
+test:
+	forge test -vvv
+
+# Deploy Task Mailbox
+.PHONY: deploy-task-mailbox
+deploy-task-mailbox:
+	forge script script/deploy/DeployTaskMailbox.s.sol \
+		--rpc-url $(RPC_URL) \
+		--broadcast \
+		--sig "run(string, address, address)" $(ENVIRONMENT) $(BN254_CERTIFICATE_VERIFIER) $(ECDSA_CERTIFICATE_VERIFIER) \
+		--slow \
+		-vvvv
+
+# Deploy AVS L1 Contracts
+.PHONY: deploy-avs-l1-contracts
+deploy-avs-l1-contracts:
+	forge script script/deploy/DeployAVSL1Contracts.s.sol \
+		--rpc-url $(RPC_URL) \
+		--broadcast \
+		--sig "run(string, address, address, address, uint32, uint32)" $(ENVIRONMENT) $(AVS_ADDRESS) $(ALLOCATION_MANAGER_ADDRESS) $(KEY_REGISTRAR_ADDRESS) $(AGGREGATOR_OPERATOR_SET_ID) $(EXECUTOR_OPERATOR_SET_ID) \
+		--slow \
+		-vvvv
+
+# Deploy AVS L2 Contracts
+.PHONY: deploy-avs-l2-contracts
+deploy-avs-l2-contracts:
+	forge script script/deploy/DeployAVSL2Contracts.s.sol \
+		--rpc-url $(RPC_URL) \
+		--broadcast \
+		--sig "run(string)" $(ENVIRONMENT) \
+		--slow \
+		-vvvv
+
+# Setup AVS Task Mailbox Config
+.PHONY: setup-avs-task-mailbox-config
+setup-avs-task-mailbox-config:
+	forge script script/setup/SetupAVSTaskMailboxConfig.s.sol \
+		--rpc-url $(RPC_URL) \
+		--broadcast \
+		--sig "run(string, uint32, uint96, uint8)" $(ENVIRONMENT) $(EXECUTOR_OPERATOR_SET_ID) $(TASK_SLA) $(CURVE_TYPE) \
+		--slow \
+		-vvvv
+
+# Deploy Custom L1 Contracts
+.PHONY: deploy-custom-contracts-l1
+deploy-custom-contracts-l1:
+	forge script $(shell pwd)/../../contracts/script/DeployMyL1Contracts.s.sol \
+		--lib-paths . \
+		--rpc-url $(RPC_URL) \
+		--broadcast \
+		--sig "run(string, string)" "$(ENVIRONMENT)" '$(CONTEXT)'\
+		--slow \
+		-vvvv
+
+# Deploy Custom L2 Contracts
+.PHONY: deploy-custom-contracts-l2
+deploy-custom-contracts-l2:
+	forge script $(shell pwd)/../../contracts/script/DeployMyL2Contracts.s.sol \
+		--lib-paths . \
+		--rpc-url $(RPC_URL) \
+		--broadcast \
+		--sig "run(string, string)" "$(ENVIRONMENT)" '$(CONTEXT)'\
+		--slow \
+		-vvvv
+
+# Create Task
+.PHONY: create-task
+create-task:
+	forge script script/call/CreateTask.s.sol \
+		--rpc-url $(RPC_URL) \
+		--broadcast \
+		--sig "run(string, address, uint32, bytes)" $(ENVIRONMENT) $(AVS_ADDRESS) $(EXECUTOR_OPERATOR_SET_ID) $(PAYLOAD) \
+		--slow \
+		-vvvv
+
+# Helper message
+.PHONY: help
+help:
+	@echo "Available commands:"
+	@echo "  make build - Build the project"
+	@echo "  make test - Test the project"
+	@echo "  make deploy-task-mailbox    - Deploy Task Mailbox"
+	@echo "  make deploy-avs-l1-contracts AVS_ADDRESS=0x... - Deploy AVS L1 Contracts"
+	@echo "  make deploy-avs-l2-contracts - Deploy AVS L2 Contracts"
+	@echo "  make setup-avs-task-mailbox-config TASK_MAILBOX_ADDRESS=0x... CERTIFICATE_VERIFIER_ADDRESS=0x... TASK_HOOK_ADDRESS=0x... - Setup AVS Task Mailbox Config"
+	@echo "  make create-task TASK_MAILBOX_ADDRESS=0x... AVS_ADDRESS=0x... VALUE=5 - Create Task"
+	@echo ""
+	@echo "Note: Make sure to set RPC_URL and PRIVATE_KEY in your environment or .env file" 

--- a/.devkit/contracts/README.md
+++ b/.devkit/contracts/README.md
@@ -1,0 +1,4 @@
+## ⚠️ Warning: This is Alpha, non audited code ⚠️
+Hourglass is in active development and is not yet audited. Use at your own risk.
+
+# hourglass-contracts-template

--- a/.devkit/contracts/README.md
+++ b/.devkit/contracts/README.md
@@ -1,4 +1,0 @@
-## ⚠️ Warning: This is Alpha, non audited code ⚠️
-Hourglass is in active development and is not yet audited. Use at your own risk.
-
-# hourglass-contracts-template

--- a/.devkit/contracts/foundry.toml
+++ b/.devkit/contracts/foundry.toml
@@ -1,0 +1,44 @@
+[profile.default]
+src = "src"
+out = "out"
+libs = ["lib"]
+fs_permissions = [{ access = "read-write", path = "./"}]
+show_progress=true
+gas_reports = ["*"]
+
+# Defines paths for Solidity imports.
+remappings = [
+    "forge-std/=lib/forge-std/src/",
+    "@hourglass-monorepo/=lib/hourglass-monorepo/contracts/",
+    "@eigenlayer-middleware/=lib/hourglass-monorepo/contracts/lib/eigenlayer-middleware/",
+    "@eigenlayer-contracts/=lib/hourglass-monorepo/contracts/lib/eigenlayer-middleware/lib/eigenlayer-contracts/",
+    "@openzeppelin/=lib/hourglass-monorepo/contracts/lib/eigenlayer-middleware/lib/openzeppelin-contracts/",
+    "@openzeppelin-upgrades/=lib/hourglass-monorepo/contracts/lib/eigenlayer-middleware/lib/openzeppelin-contracts-upgradeable/",
+    "@project/=../../contracts/src/",
+]
+
+# Specifies the exact version of Solidity to use, overriding auto-detection.
+solc_version = '0.8.27'
+# If set to true, changes compilation pipeline to go through the new IR optimizer.
+via_ir = false
+# Whether or not to enable the Solidity optimizer.
+optimizer = true
+# The number of runs specifies roughly how often each opcode of the deployed code will be executed 
+# across the life-time of the contract. This means it is a trade-off parameter between code size (deploy cost) 
+# and code execution cost (cost after deployment).
+optimizer_runs = 200
+
+[rpc_endpoints]
+mainnet = "${RPC_MAINNET}"
+holesky = "${RPC_HOLESKY}"
+
+[fmt]
+bracket_spacing = false
+int_types = "long"
+line_length = 120
+multiline_func_header = "params_first"
+number_underscore = "thousands"
+quote_style = "double"
+tab_width = 4
+
+# See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/.devkit/contracts/foundry.toml
+++ b/.devkit/contracts/foundry.toml
@@ -9,11 +9,10 @@ gas_reports = ["*"]
 # Defines paths for Solidity imports.
 remappings = [
     "forge-std/=lib/forge-std/src/",
-    "@hourglass-monorepo/=lib/hourglass-monorepo/contracts/",
-    "@eigenlayer-middleware/=lib/hourglass-monorepo/contracts/lib/eigenlayer-middleware/",
-    "@eigenlayer-contracts/=lib/hourglass-monorepo/contracts/lib/eigenlayer-middleware/lib/eigenlayer-contracts/",
-    "@openzeppelin/=lib/hourglass-monorepo/contracts/lib/eigenlayer-middleware/lib/openzeppelin-contracts/",
-    "@openzeppelin-upgrades/=lib/hourglass-monorepo/contracts/lib/eigenlayer-middleware/lib/openzeppelin-contracts-upgradeable/",
+    "@eigenlayer-middleware/=lib/eigenlayer-middleware/",
+    "@eigenlayer-contracts/=lib/eigenlayer-middleware/lib/eigenlayer-contracts/",
+    "@openzeppelin/=lib/eigenlayer-middleware/lib/openzeppelin-contracts/",
+    "@openzeppelin-upgrades/=lib/eigenlayer-middleware/lib/openzeppelin-contracts-upgradeable/",
     "@project/=../../contracts/src/",
 ]
 

--- a/.devkit/contracts/script/call/CreateTask.s.sol
+++ b/.devkit/contracts/script/call/CreateTask.s.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import {Script, console} from "forge-std/Script.sol";
+import {stdJson} from "forge-std/StdJson.sol";
+import {OperatorSet} from "@eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
+
+import {ITaskMailbox, ITaskMailboxTypes} from "@hourglass-monorepo/src/interfaces/core/ITaskMailbox.sol";
+
+contract CreateTask is Script {
+    using stdJson for string;
+
+    function run(string memory environment, address avs, uint32 executorOperatorSetId, bytes memory payload) public {
+        // Read TaskMailbox address from config
+        address taskMailbox = _readTaskMailboxAddress(environment);
+        console.log("Task Mailbox:", taskMailbox);
+
+        // Load the private key from the environment variable
+        uint256 appPrivateKey = vm.envUint("PRIVATE_KEY_APP");
+        address app = vm.addr(appPrivateKey);
+
+        vm.startBroadcast(appPrivateKey);
+        console.log("App address:", app);
+
+        // Call createTask
+        OperatorSet memory executorOperatorSet = OperatorSet({avs: avs, id: executorOperatorSetId});
+        ITaskMailboxTypes.TaskParams memory taskParams = ITaskMailboxTypes.TaskParams({
+            refundCollector: address(0),
+            avsFee: 0,
+            executorOperatorSet: executorOperatorSet,
+            payload: payload
+        });
+        bytes32 taskHash = ITaskMailbox(taskMailbox).createTask(taskParams);
+        console.log("Created task with hash:");
+        console.logBytes32(taskHash);
+        ITaskMailboxTypes.Task memory task = ITaskMailbox(taskMailbox).getTaskInfo(taskHash);
+        console.log("Task status:", uint8(task.status));
+        console.logBytes(task.payload);
+
+        vm.stopBroadcast();
+    }
+
+    function _readTaskMailboxAddress(
+        string memory environment
+    ) internal view returns (address) {
+        // Load the output file
+        string memory hourglassConfigFile =
+            string.concat("script/", environment, "/output/deploy_hourglass_core_output.json");
+        string memory hourglassConfig = vm.readFile(hourglassConfigFile);
+
+        // Parse and return the TaskMailbox address
+        return stdJson.readAddress(hourglassConfig, ".addresses.taskMailbox");
+    }
+}

--- a/.devkit/contracts/script/call/CreateTask.s.sol
+++ b/.devkit/contracts/script/call/CreateTask.s.sol
@@ -4,8 +4,7 @@ pragma solidity ^0.8.27;
 import {Script, console} from "forge-std/Script.sol";
 import {stdJson} from "forge-std/StdJson.sol";
 import {OperatorSet} from "@eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
-
-import {ITaskMailbox, ITaskMailboxTypes} from "@hourglass-monorepo/src/interfaces/core/ITaskMailbox.sol";
+import {ITaskMailbox, ITaskMailboxTypes} from "@eigenlayer-contracts/src/contracts/interfaces/ITaskMailbox.sol";
 
 contract CreateTask is Script {
     using stdJson for string;
@@ -26,7 +25,6 @@ contract CreateTask is Script {
         OperatorSet memory executorOperatorSet = OperatorSet({avs: avs, id: executorOperatorSetId});
         ITaskMailboxTypes.TaskParams memory taskParams = ITaskMailboxTypes.TaskParams({
             refundCollector: address(0),
-            avsFee: 0,
             executorOperatorSet: executorOperatorSet,
             payload: payload
         });

--- a/.devkit/contracts/script/deploy/DeployAVSL1Contracts.s.sol
+++ b/.devkit/contracts/script/deploy/DeployAVSL1Contracts.s.sol
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import {Script, console} from "forge-std/Script.sol";
+import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ITransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+import {IAllocationManager} from "@eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
+import {IKeyRegistrar} from "@eigenlayer-contracts/src/contracts/interfaces/IKeyRegistrar.sol";
+
+import {ITaskAVSRegistrarBaseTypes} from "@hourglass-monorepo/src/interfaces/avs/l1/ITaskAVSRegistrarBase.sol";
+
+import {TaskAVSRegistrar} from "@project/l1-contracts/TaskAVSRegistrar.sol";
+
+contract DeployAVSL1Contracts is Script {
+    function run(
+        string memory environment,
+        address avs,
+        address allocationManager,
+        address keyRegistrar,
+        uint32 aggregatorOperatorSetId,
+        uint32 executorOperatorSetId
+    ) public {
+        // Load the private key from the environment variable
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY_DEPLOYER");
+        address deployer = vm.addr(deployerPrivateKey);
+
+        // Deploy the TaskAVSRegistrar middleware contract with proxy pattern
+        vm.startBroadcast(deployerPrivateKey);
+        console.log("Deployer address:", deployer);
+
+        // Create initial config
+        uint32[] memory executorOperatorSetIds = new uint32[](1);
+        executorOperatorSetIds[0] = executorOperatorSetId;
+        ITaskAVSRegistrarBaseTypes.AvsConfig memory initialConfig = ITaskAVSRegistrarBaseTypes.AvsConfig({
+            aggregatorOperatorSetId: aggregatorOperatorSetId,
+            executorOperatorSetIds: executorOperatorSetIds
+        });
+
+        // Deploy ProxyAdmin
+        ProxyAdmin proxyAdmin = new ProxyAdmin();
+        console.log("ProxyAdmin deployed to:", address(proxyAdmin));
+
+        // Deploy implementation
+        TaskAVSRegistrar taskAVSRegistrarImpl = new TaskAVSRegistrar(
+            avs, IAllocationManager(allocationManager), IKeyRegistrar(keyRegistrar)
+        );
+        console.log("TaskAVSRegistrar implementation deployed to:", address(taskAVSRegistrarImpl));
+
+        // Deploy proxy with initialization
+        TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(
+            address(taskAVSRegistrarImpl),
+            address(proxyAdmin),
+            abi.encodeWithSelector(TaskAVSRegistrar.initialize.selector, avs, initialConfig)
+        );
+        console.log("TaskAVSRegistrar proxy deployed to:", address(proxy));
+
+        // Transfer ProxyAdmin ownership to avs (or a multisig in production)
+        proxyAdmin.transferOwnership(avs);
+
+        vm.stopBroadcast();
+
+        // Write deployment info to output file
+        _writeOutputToJson(environment, address(proxy), address(taskAVSRegistrarImpl), address(proxyAdmin));
+    }
+
+    function _writeOutputToJson(string memory environment, address taskAVSRegistrarProxy, address taskAVSRegistrarImpl, address proxyAdmin) internal {
+        // Add the addresses object
+        string memory addresses = "addresses";
+        vm.serializeAddress(addresses, "taskAVSRegistrar", taskAVSRegistrarProxy);
+        vm.serializeAddress(addresses, "taskAVSRegistrarImpl", taskAVSRegistrarImpl);
+        addresses = vm.serializeAddress(addresses, "l1ProxyAdmin", proxyAdmin);
+
+        // Add the chainInfo object
+        string memory chainInfo = "chainInfo";
+        chainInfo = vm.serializeUint(chainInfo, "chainId", block.chainid);
+
+        // Finalize the JSON
+        string memory finalJson = "final";
+        vm.serializeString(finalJson, "addresses", addresses);
+        finalJson = vm.serializeString(finalJson, "chainInfo", chainInfo);
+
+        // Write to output file
+        string memory outputFile = string.concat("script/", environment, "/output/deploy_avs_l1_output.json");
+        vm.writeJson(finalJson, outputFile);
+    }
+}

--- a/.devkit/contracts/script/deploy/DeployAVSL1Contracts.s.sol
+++ b/.devkit/contracts/script/deploy/DeployAVSL1Contracts.s.sol
@@ -8,8 +8,7 @@ import {ITransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transp
 
 import {IAllocationManager} from "@eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
 import {IKeyRegistrar} from "@eigenlayer-contracts/src/contracts/interfaces/IKeyRegistrar.sol";
-
-import {ITaskAVSRegistrarBaseTypes} from "@hourglass-monorepo/src/interfaces/avs/l1/ITaskAVSRegistrarBase.sol";
+import {ITaskAVSRegistrarBaseTypes} from "@eigenlayer-middleware/src/interfaces/ITaskAVSRegistrarBase.sol";
 
 import {TaskAVSRegistrar} from "@project/l1-contracts/TaskAVSRegistrar.sol";
 

--- a/.devkit/contracts/script/deploy/DeployAVSL2Contracts.s.sol
+++ b/.devkit/contracts/script/deploy/DeployAVSL2Contracts.s.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import {Script, console} from "forge-std/Script.sol";
+
+import {AVSTaskHook} from "@project/l2-contracts/AVSTaskHook.sol";
+
+contract DeployAVSL2Contracts is Script {
+    function run(
+        string memory environment
+    ) public {
+        // Load the private key from the environment variable
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY_DEPLOYER");
+        address deployer = vm.addr(deployerPrivateKey);
+
+        // Deploy the AVSTaskHook contract
+        vm.startBroadcast(deployerPrivateKey);
+        console.log("Deployer address:", deployer);
+
+        AVSTaskHook avsTaskHook = new AVSTaskHook();
+        console.log("AVSTaskHook deployed to:", address(avsTaskHook));
+
+        vm.stopBroadcast();
+
+        // Write deployment info to output file
+        _writeOutputToJson(environment, address(avsTaskHook));
+    }
+
+    function _writeOutputToJson(string memory environment, address avsTaskHook) internal {
+        // Add the addresses object
+        string memory addresses = "addresses";
+        addresses = vm.serializeAddress(addresses, "avsTaskHook", avsTaskHook);
+
+        // Add the chainInfo object
+        string memory chainInfo = "chainInfo";
+        chainInfo = vm.serializeUint(chainInfo, "chainId", block.chainid);
+
+        // Finalize the JSON
+        string memory finalJson = "final";
+        vm.serializeString(finalJson, "addresses", addresses);
+        finalJson = vm.serializeString(finalJson, "chainInfo", chainInfo);
+
+        // Write to output file
+        string memory outputFile = string.concat("script/", environment, "/output/deploy_avs_l2_output.json");
+        vm.writeJson(finalJson, outputFile);
+    }
+}

--- a/.devkit/contracts/script/deploy/DeployTaskMailbox.s.sol
+++ b/.devkit/contracts/script/deploy/DeployTaskMailbox.s.sol
@@ -7,8 +7,7 @@ import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transpa
 import {ITransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
 import {IKeyRegistrarTypes} from "@eigenlayer-contracts/src/contracts/interfaces/IKeyRegistrar.sol";
-
-import {TaskMailbox} from "@hourglass-monorepo/src/core/TaskMailbox.sol";
+import {TaskMailbox} from "@eigenlayer-contracts/src/contracts/avs/task/TaskMailbox.sol";
 
 contract DeployTaskMailbox is Script {
     function run(

--- a/.devkit/contracts/script/deploy/DeployTaskMailbox.s.sol
+++ b/.devkit/contracts/script/deploy/DeployTaskMailbox.s.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import {Script, console} from "forge-std/Script.sol";
+import {ProxyAdmin} from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import {TransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import {ITransparentUpgradeableProxy} from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+import {IKeyRegistrarTypes} from "@eigenlayer-contracts/src/contracts/interfaces/IKeyRegistrar.sol";
+
+import {TaskMailbox} from "@hourglass-monorepo/src/core/TaskMailbox.sol";
+
+contract DeployTaskMailbox is Script {
+    function run(
+        string memory environment,
+        address bn254CertificateVerifier,
+        address ecdsaCertificateVerifier
+    ) public {
+        // Load the private key from the environment variable
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY_DEPLOYER");
+        address deployer = vm.addr(deployerPrivateKey);
+
+        // Deploy the TaskMailbox contract with proxy pattern
+        vm.startBroadcast(deployerPrivateKey);
+        console.log("Deployer address:", deployer);
+
+        // Deploy ProxyAdmin
+        ProxyAdmin proxyAdmin = new ProxyAdmin();
+        console.log("ProxyAdmin deployed to:", address(proxyAdmin));
+
+        // Deploy implementation
+        TaskMailbox taskMailboxImpl = new TaskMailbox(bn254CertificateVerifier, ecdsaCertificateVerifier, "0.0.1");
+        console.log("TaskMailbox implementation deployed to:", address(taskMailboxImpl));
+
+        // Deploy proxy with initialization
+        TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(
+            address(taskMailboxImpl),
+            address(proxyAdmin),
+            abi.encodeWithSelector(TaskMailbox.initialize.selector, deployer)
+        );
+        console.log("TaskMailbox proxy deployed to:", address(proxy));
+
+        // Transfer ProxyAdmin ownership to deployer (or a multisig in production)
+        proxyAdmin.transferOwnership(deployer);
+
+        vm.stopBroadcast();
+
+        // Write deployment info to output file
+        _writeOutputToJson(environment, address(proxy), address(taskMailboxImpl), address(proxyAdmin));
+    }
+
+    function _writeOutputToJson(string memory environment, address taskMailboxProxy, address taskMailboxImpl, address proxyAdmin) internal {
+        // Add the addresses object
+        string memory addresses = "addresses";
+        vm.serializeAddress(addresses, "taskMailbox", taskMailboxProxy);
+        vm.serializeAddress(addresses, "taskMailboxImpl", taskMailboxImpl);
+        addresses = vm.serializeAddress(addresses, "l2ProxyAdmin", proxyAdmin);
+
+        // Add the chainInfo object
+        string memory chainInfo = "chainInfo";
+        chainInfo = vm.serializeUint(chainInfo, "chainId", block.chainid);
+
+        // Finalize the JSON
+        string memory finalJson = "final";
+        vm.serializeString(finalJson, "addresses", addresses);
+        finalJson = vm.serializeString(finalJson, "chainInfo", chainInfo);
+
+        // Write to output file
+        string memory outputFile = string.concat("script/", environment, "/output/deploy_hourglass_core_output.json");
+        vm.writeJson(finalJson, outputFile);
+    }
+}

--- a/.devkit/contracts/script/devnet/output/deploy_avs_l1_output.json
+++ b/.devkit/contracts/script/devnet/output/deploy_avs_l1_output.json
@@ -1,0 +1,8 @@
+{
+  "addresses": {
+    "taskAVSRegistrar": ""
+  },
+  "chainInfo": {
+    "chainId": 0,
+  }
+}

--- a/.devkit/contracts/script/devnet/output/deploy_avs_l2_output.json
+++ b/.devkit/contracts/script/devnet/output/deploy_avs_l2_output.json
@@ -1,0 +1,8 @@
+{
+  "addresses": {
+    "avsTaskHook": ""
+  },
+  "chainInfo": {
+    "chainId": 0
+  }
+}

--- a/.devkit/contracts/script/devnet/output/deploy_custom_contracts_l1_output.json
+++ b/.devkit/contracts/script/devnet/output/deploy_custom_contracts_l1_output.json
@@ -1,0 +1,8 @@
+{
+  "addresses": {
+    "": ""
+  },
+  "chainInfo": {
+    "chainId": 0
+  }
+}

--- a/.devkit/contracts/script/devnet/output/deploy_custom_contracts_l2_output.json
+++ b/.devkit/contracts/script/devnet/output/deploy_custom_contracts_l2_output.json
@@ -1,0 +1,8 @@
+{
+  "addresses": {
+    "": ""
+  },
+  "chainInfo": {
+    "chainId": 0
+  }
+}

--- a/.devkit/contracts/script/devnet/output/deploy_hourglass_core_output.json
+++ b/.devkit/contracts/script/devnet/output/deploy_hourglass_core_output.json
@@ -1,0 +1,8 @@
+{
+  "addresses": {
+    "taskMailbox": ""
+  },
+  "chainInfo": {
+    "chainId": 0
+  }
+}

--- a/.devkit/contracts/script/setup/SetupAVSTaskMailboxConfig.s.sol
+++ b/.devkit/contracts/script/setup/SetupAVSTaskMailboxConfig.s.sol
@@ -7,9 +7,8 @@ import {stdJson} from "forge-std/StdJson.sol";
 import {IKeyRegistrarTypes} from "@eigenlayer-contracts/src/contracts/interfaces/IKeyRegistrar.sol";
 import {OperatorSet, OperatorSetLib} from "@eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-
-import {ITaskMailbox, ITaskMailboxTypes} from "@hourglass-monorepo/src/interfaces/core/ITaskMailbox.sol";
-import {IAVSTaskHook} from "@hourglass-monorepo/src/interfaces/avs/l2/IAVSTaskHook.sol";
+import {ITaskMailbox, ITaskMailboxTypes} from "@eigenlayer-contracts/src/contracts/interfaces/ITaskMailbox.sol";
+import {IAVSTaskHook} from "@eigenlayer-contracts/src/contracts/interfaces/IAVSTaskHook.sol";
 
 contract SetupAVSTaskMailboxConfig is Script {
     using stdJson for string;
@@ -33,12 +32,15 @@ contract SetupAVSTaskMailboxConfig is Script {
         // Set the Executor Operator Set Task Config
         ITaskMailboxTypes.ExecutorOperatorSetTaskConfig memory executorOperatorSetTaskConfig = ITaskMailboxTypes
             .ExecutorOperatorSetTaskConfig({
-            curveType: IKeyRegistrarTypes.CurveType(curveType),
             taskHook: IAVSTaskHook(taskHook),
-            feeToken: IERC20(address(0)),
-            feeCollector: address(0),
             taskSLA: taskSLA,
-            stakeProportionThreshold: 10_000,
+            feeToken: IERC20(address(0)),
+            curveType: IKeyRegistrarTypes.CurveType(curveType),
+            feeCollector: address(0),
+            consensus: ITaskMailboxTypes.Consensus({
+                consensusType: ITaskMailboxTypes.ConsensusType.STAKE_PROPORTION_THRESHOLD,
+                value: abi.encode(10_000)
+            }),
             taskMetadata: bytes("")
         });
         ITaskMailbox(taskMailbox).setExecutorOperatorSetTaskConfig(

--- a/.devkit/contracts/script/setup/SetupAVSTaskMailboxConfig.s.sol
+++ b/.devkit/contracts/script/setup/SetupAVSTaskMailboxConfig.s.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.27;
+
+import {Script, console} from "forge-std/Script.sol";
+import {stdJson} from "forge-std/StdJson.sol";
+
+import {IKeyRegistrarTypes} from "@eigenlayer-contracts/src/contracts/interfaces/IKeyRegistrar.sol";
+import {OperatorSet, OperatorSetLib} from "@eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {ITaskMailbox, ITaskMailboxTypes} from "@hourglass-monorepo/src/interfaces/core/ITaskMailbox.sol";
+import {IAVSTaskHook} from "@hourglass-monorepo/src/interfaces/avs/l2/IAVSTaskHook.sol";
+
+contract SetupAVSTaskMailboxConfig is Script {
+    using stdJson for string;
+
+    function run(string memory environment, uint32 executorOperatorSetId, uint96 taskSLA, uint8 curveType) public {
+        // Read addresses from config files
+        address taskMailbox = _readHourglassConfigAddress(environment, "taskMailbox");
+        console.log("Task Mailbox:", taskMailbox);
+
+        // Read AVS L2 contract addresses
+        address taskHook = _readAVSL2ConfigAddress(environment, "avsTaskHook");
+        console.log("AVS Task Hook:", taskHook);
+
+        // Load the private key from the environment variable
+        uint256 avsPrivateKey = vm.envUint("PRIVATE_KEY_AVS");
+        address avs = vm.addr(avsPrivateKey);
+
+        vm.startBroadcast(avsPrivateKey);
+        console.log("AVS address:", avs);
+
+        // Set the Executor Operator Set Task Config
+        ITaskMailboxTypes.ExecutorOperatorSetTaskConfig memory executorOperatorSetTaskConfig = ITaskMailboxTypes
+            .ExecutorOperatorSetTaskConfig({
+            curveType: IKeyRegistrarTypes.CurveType(curveType),
+            taskHook: IAVSTaskHook(taskHook),
+            feeToken: IERC20(address(0)),
+            feeCollector: address(0),
+            taskSLA: taskSLA,
+            stakeProportionThreshold: 10_000,
+            taskMetadata: bytes("")
+        });
+        ITaskMailbox(taskMailbox).setExecutorOperatorSetTaskConfig(
+            OperatorSet(avs, executorOperatorSetId), executorOperatorSetTaskConfig
+        );
+        ITaskMailboxTypes.ExecutorOperatorSetTaskConfig memory executorOperatorSetTaskConfigStored =
+            ITaskMailbox(taskMailbox).getExecutorOperatorSetTaskConfig(OperatorSet(avs, executorOperatorSetId));
+        console.log(
+            "Executor Operator Set Task Config set with curve type:",
+            uint8(executorOperatorSetTaskConfigStored.curveType),
+            address(executorOperatorSetTaskConfigStored.taskHook)
+        );
+
+        vm.stopBroadcast();
+    }
+
+    function _readHourglassConfigAddress(
+        string memory environment,
+        string memory key
+    ) internal view returns (address) {
+        // Load the Hourglass config file
+        string memory hourglassConfigFile =
+            string.concat("script/", environment, "/output/deploy_hourglass_core_output.json");
+        string memory hourglassConfig = vm.readFile(hourglassConfigFile);
+
+        // Parse and return the address
+        return stdJson.readAddress(hourglassConfig, string.concat(".addresses.", key));
+    }
+
+    function _readAVSL2ConfigAddress(string memory environment, string memory key) internal view returns (address) {
+        // Load the AVS L2 config file
+        string memory avsL2ConfigFile = string.concat("script/", environment, "/output/deploy_avs_l2_output.json");
+        string memory avsL2Config = vm.readFile(avsL2ConfigFile);
+
+        // Parse and return the address
+        return stdJson.readAddress(avsL2Config, string.concat(".addresses.", key));
+    }
+}

--- a/.devkit/scripts/upgrade
+++ b/.devkit/scripts/upgrade
@@ -32,6 +32,37 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # Navigate to the parent directories to find .devkit
 PROJECT_BASE_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
 
+# check if .devkit/contracts/.git exists
+if [[ ! -d "$originalProjectDir/.devkit/contracts/.git" ]]; then
+    cd $originalProjectDir
+    log "cd to '$originalProjectDir'"
+    log ".devkit/contracts is still a git submodule, removing"
+
+    log "running submodule deinit.."
+    git submodule deinit -f .devit/contracts || true
+
+    log "removing submodule .devkit/contracts from git config.."
+    git rm -rf .devkit/contracts || true
+
+    log "removing .devkit/contracts directory.."
+    rm -rf .devkit/contracts || true
+
+    log "removing .devkit/contracts/.git directory.."
+    rm -rf .git/modules/.devkit/contracts || true
+
+
+    set +e
+    if [ -n "$(git status --porcelain)" ]; then
+        log "staging and committing changes.."
+        git add .
+        git commit -m 'chore: removed .devkit/contracts submodule as part of upgrade'
+    fi
+    set -e
+    cd -
+fi
+log "Updating .devkit/contracts from git submodule to regular directory..."
+cp -rfv "${PROJECT_BASE_DIR}/.devkit/contracts" $originalProjectDir/.devkit
+
 # Copy everything from .devkit except for ./contracts
 for item in "${PROJECT_BASE_DIR}/.devkit/"*; do
   [ "$(basename "$item")" = "contracts" ] && continue
@@ -43,77 +74,10 @@ cp -rfv "${PROJECT_BASE_DIR}/.hourglass" $originalProjectDir
 cp -rfv "${PROJECT_BASE_DIR}/Dockerfile" $originalProjectDir
 cp -rfv "${PROJECT_BASE_DIR}/contracts/" $originalProjectDir/contracts
 
-cd $PROJECT_BASE_DIR/.devkit/contracts
-git_repo=$(git config --get remote.origin.url | tr -d '\n')
-git_ref=$(git rev-parse HEAD | tr -d '\n')
-cd -
-
-migratedContracts=""
-
-# -----------------------------------------------------------------------------
-# In order for forge to play nice with things, .devkit/contracts needs to
-# remain as a proper git submodule. Until this logic was added, it was not
-# a submodule, but just a simple directory. This caused some funky behavior
-# like requiring the end-user to commit and track everything in .devkit/contracts
-# which is not ideal nor necessary anymore. In fact, the user shouldnt be modifying
-# anything in .devkit/contracts at all.
-# -----------------------------------------------------------------------------
-# first check to see if the .devkit/contracts directory is already a submodule
-if ! git -C "$originalProjectDir" ls-tree -r HEAD | grep -q "160000.*\.devkit/contracts$"; then
-    log "Contracts directory is not a submodule, making it one"
-
-    cd $originalProjectDir
-    if [[ -d ".devkit/contracts" ]]; then
-        log "Moving existing .devkit/contracts to .oldcontracts"
-        cp -r $originalProjectDir/.devkit/contracts $originalProjectDir/.oldcontracts
-
-        log "Removing existing .devkit/contracts directory from git cache"
-        rm -rf .devkit/contracts
-        git rm -rf --cached .devkit/contracts
-        git commit -m "fix: remove improperly added .devkit/contracts directory"
-    else
-        log "No existing .devkit/contracts found, creating new submodule"
-    fi
-
-    log "repo url: $git_repo"
-    log "repo ref: $git_ref"
-
-    if [[ ! -d ".devkit/contracts" ]]; then
-        log "Creating .devkit/contracts directory"
-    fi
-
-    log "Adding .devkit/contracts as a submodule..."
-    git submodule add --force $git_repo .devkit/contracts
-
-    migratedContracts="1"
-
-    # cleanup
-    rm -rf $originalProjectDir/.oldcontracts || true
-fi
-
-log "Updating contracts submodule to desired commit..."
-cd $originalProjectDir/.devkit/contracts
-git fetch origin $git_ref
-git checkout $git_ref
-
-cd $originalProjectDir
-
 log "Updating submodules..."
-
-# update submodules inside .devkit/contracts
-git -C .devkit/contracts submodule update --init --recursive
-
-# update all submodules at root except for .devkit/contracts
-for sub in $(git config --file .gitmodules --get-regexp path | awk '{print $2}' | grep -v '.devkit/contracts'); do
-    git submodule update --init "$sub"
-done
+git submodule update --init --recursive
 
 log "Upgrade complete!"
-
-if [[ -n "$migratedContracts" ]]; then
-    log "Successfully migrated your .devkit/contracts to a submodule."
-    log "Please run 'git add .devkit/contracts' to stage the changes."
-fi
 
 
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule ".devkit/contracts"]
-	path = .devkit/contracts
-	url = https://github.com/Layr-Labs/hourglass-contracts-template
-	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,7 @@
+[submodule ".devkit/contracts/lib/forge-std"]
+	path = .devkit/contracts/lib/forge-std
+	url = https://github.com/foundry-rs/forge-std
+[submodule ".devkit/contracts/lib/eigenlayer-middleware"]
+	path = .devkit/contracts/lib/eigenlayer-middleware
+	url = https://github.com/Layr-Labs/eigenlayer-middleware
+	branch = release-dev/hourglass

--- a/contracts/script/DeployMyL2Contracts.s.sol
+++ b/contracts/script/DeployMyL2Contracts.s.sol
@@ -7,7 +7,7 @@ import {stdJson} from "forge-std/StdJson.sol";
 import {IBN254CertificateVerifier} from
     "@eigenlayer-contracts/src/contracts/interfaces/IBN254CertificateVerifier.sol";
 import {IECDSACertificateVerifier} from "@eigenlayer-contracts/src/contracts/interfaces/IECDSACertificateVerifier.sol";
-import {ITaskMailbox} from "@hourglass-monorepo/src/interfaces/core/ITaskMailbox.sol";
+import {ITaskMailbox} from "@eigenlayer-contracts/src/contracts/interfaces/ITaskMailbox.sol";
 
 import {AVSTaskHook} from "@project/l2-contracts/AVSTaskHook.sol";
 import {HelloWorldL2} from "@project/l2-contracts/HelloWorldL2.sol"; // Import your L2 custom contract

--- a/contracts/src/l1-contracts/TaskAVSRegistrar.sol
+++ b/contracts/src/l1-contracts/TaskAVSRegistrar.sol
@@ -3,8 +3,7 @@ pragma solidity ^0.8.27;
 
 import {IAllocationManager} from "@eigenlayer-contracts/src/contracts/interfaces/IAllocationManager.sol";
 import {IKeyRegistrar} from "@eigenlayer-contracts/src/contracts/interfaces/IKeyRegistrar.sol";
-
-import {TaskAVSRegistrarBase} from "@hourglass-monorepo/src/avs/TaskAVSRegistrarBase.sol";
+import {TaskAVSRegistrarBase} from "@eigenlayer-middleware/src/avs/task/TaskAVSRegistrarBase.sol";
 
 contract TaskAVSRegistrar is TaskAVSRegistrarBase {
     /**

--- a/contracts/src/l2-contracts/AVSTaskHook.sol
+++ b/contracts/src/l2-contracts/AVSTaskHook.sol
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.27;
 
-import {OperatorSet} from "@eigenlayer-contracts/src/contracts/libraries/OperatorSetLib.sol";
-import {IAVSTaskHook} from "@hourglass-monorepo/src/interfaces/avs/l2/IAVSTaskHook.sol";
-import {ITaskMailboxTypes} from "@hourglass-monorepo/src/interfaces/core/ITaskMailbox.sol";
+import {IAVSTaskHook} from "@eigenlayer-contracts/src/contracts/interfaces/IAVSTaskHook.sol";
+import {ITaskMailboxTypes} from "@eigenlayer-contracts/src/contracts/interfaces/ITaskMailbox.sol";
 
 contract AVSTaskHook is IAVSTaskHook {
     function validatePreTaskCreation(
@@ -35,8 +34,7 @@ contract AVSTaskHook is IAVSTaskHook {
     }
 
     function calculateTaskFee(
-        OperatorSet memory, /*operatorSet*/
-        bytes memory /*payload*/
+        ITaskMailboxTypes.TaskParams memory /*taskParams*/
     ) external view returns (uint96) {
         //TODO: Implement
     }


### PR DESCRIPTION
**Motivation:**

We need to do the following:
* Make `.devkit/contracts` into a regular directory (from a git submodule)
* Update the dependencies in `.devkit/contracts` to pull the latest changes from `eigenlayer-middleware` after having moved the TaskMailbox and TaskAVSRegistrar from the hourglass monorepo to the relevant contracts repositories.