### PR TITLE
fix: add --lang flag to build script

### DIFF
--- a/.devkit/scripts/build
+++ b/.devkit/scripts/build
@@ -12,6 +12,7 @@ ensureDocker
 # Parse command line arguments
 IMAGE_NAME=""
 VERSION=""
+LANGUAGE=""
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -29,6 +30,14 @@ while [[ $# -gt 0 ]]; do
       ;;
     --tag=*)
       VERSION="${1#*=}"
+      shift 1
+      ;;
+    --lang)
+      LANGUAGE="$2"
+      shift 2
+      ;;
+    --lang=*)
+      LANGUAGE="${1#*=}"
       shift 1
       ;;
     *)


### PR DESCRIPTION
This PR adds the `--lang` flag to allow the e2e test to pass for https://github.com/Layr-Labs/devkit-cli/pull/224

Note: this won't be required/used until `Performer * implementations` are ready