### PR TITLE
fix: add missing param to handlePostTaskResultSubmission

### DIFF
--- a/contracts/src/l2-contracts/AVSTaskHook.sol
+++ b/contracts/src/l2-contracts/AVSTaskHook.sol
@@ -28,6 +28,7 @@ contract AVSTaskHook is IAVSTaskHook {
     }
 
     function handlePostTaskResultSubmission(
+        address, /*caller*/
         bytes32 /*taskHash*/
     ) external {
         //TODO: Implement


### PR DESCRIPTION
Adds missing param to `AVSTaskHook.sol`