### PR TITLE
fix: sync nonce using correct key

### DIFF
--- a/.devkit/scripts/deployL2Contracts
+++ b/.devkit/scripts/deployL2Contracts
@@ -193,8 +193,8 @@ PRIVATE_KEY_DEPLOYER="${PRIVATE_KEY_DEPLOYER}" make deploy-avs-l2-contracts RPC_
 
 # Ensure nonce is in sync
 if [ "$ENVIRONMENT" == "devnet" ]; then
-    # Sync nonce for AVS account and sleep to prevent nonce conflicts
-    sync_nonce_and_sleep "${PRIVATE_KEY_AVS}" "${L2_RPC_URL}" "AVS" 1
+    # Sync nonce for deployer and sleep to prevent nonce conflicts
+    sync_nonce_and_sleep "${PRIVATE_KEY_DEPLOYER}" "${L2_RPC_URL}" "deployer" 1
 else
     # Sleep for a block on other networks
     sleep 12
@@ -205,8 +205,8 @@ if [ "$ENVIRONMENT" == "devnet" ]; then
     log "Setting up AVS Task Mailbox configuration..."
     PRIVATE_KEY_AVS="${PRIVATE_KEY_AVS}" make setup-avs-task-mailbox-config RPC_URL="${L2_RPC_URL}" ENVIRONMENT="${ENVIRONMENT}" EXECUTOR_OPERATOR_SET_ID=${EXECUTOR_OPERATOR_SET_ID} TASK_SLA=${TASK_SLA} CURVE_TYPE=2 CONTEXT="${CONTEXT}" >&2
     # Sync nonce and sleep to prevent nonce conflicts
-    sync_nonce_and_sleep "${PRIVATE_KEY_DEPLOYER}" "${L2_RPC_URL}" "deployer" 1
-fi  
+    sync_nonce_and_sleep "${PRIVATE_KEY_AVS}" "${L2_RPC_URL}" "AVS" 1
+fi
 
 # Step 4: Deploy custom contracts
 log "Deploying custom L2 contracts..."


### PR DESCRIPTION
This PR corrects the keys we feed in to `sync_nonce_and_sleep` so that we're syncing the appropriate nonce