### PR TITLE
fix: pull taskMailbox from core contracts for agg/exec configs

### DIFF
--- a/.hourglass/config/aggregator-template.yaml
+++ b/.hourglass/config/aggregator-template.yaml
@@ -6,11 +6,7 @@
 {{- $avsRegistrar = $contract.address }}
 {{- end }}
 {{- end }}
-{{- range $i, $contract := (ds "ctx").context.deployed_l2_contracts }}
-{{- if eq $contract.name "taskMailbox" }}
-{{- $taskMailboxL2 = $contract.address }}
-{{- end }}
-{{- end }}
+{{- $taskMailboxL2 := (ds "ctx").context.eigenlayer.l2.task_mailbox }}
 debug: false
 serverConfig:
   port: 9000
@@ -36,7 +32,7 @@ l1ChainId: {{ (ds "ctx").context.chains.l1.chain_id }}
 
 chains:
   - name: "ethereum"
-    network: "holesky"
+    network: "sepolia"
     chainId: {{ (ds "ctx").context.chains.l1.chain_id }}
     rpcUrl: "{{ (ds "ctx").context.chains.l1.rpc_url }}"
     pollIntervalSeconds: 2

--- a/.hourglass/config/executor-template.yaml
+++ b/.hourglass/config/executor-template.yaml
@@ -6,11 +6,7 @@
 {{- $avsRegistrar = $contract.address }}
 {{- end }}
 {{- end }}
-{{- range $i, $contract := (ds "ctx").context.deployed_l2_contracts }}
-{{- if eq $contract.name "taskMailbox" }}
-{{- $taskMailboxL2 = $contract.address }}
-{{- end }}
-{{- end }}
+{{- $taskMailboxL2 := (ds "ctx").context.eigenlayer.l2.task_mailbox }}
 grpcPort: 9090
 performerNetworkName: "hourglass-local_hourglass-network"
 operator:


### PR DESCRIPTION
We no longer deploy `TaskMailbox`, instead we're always using the core contracts deployed version. This sources the correct address from context for the agg/exec configs.