### PR TITLE
fix: configure taskMailbox for executor operatorSet on L2 deployment

### DIFF
--- a/.devkit/scripts/deployL2Contracts
+++ b/.devkit/scripts/deployL2Contracts
@@ -201,11 +201,16 @@ else
 fi
 
 # Step 3: Set up AVS Task Mailbox configuration with BN254 curve type
+log "Setting up AVS Task Mailbox configuration..."
+PRIVATE_KEY_AVS="${PRIVATE_KEY_AVS}" make setup-avs-task-mailbox-config RPC_URL="${L2_RPC_URL}" ENVIRONMENT="${ENVIRONMENT}" EXECUTOR_OPERATOR_SET_ID=${EXECUTOR_OPERATOR_SET_ID} TASK_SLA=${TASK_SLA} CURVE_TYPE=2 CONTEXT="${CONTEXT}" >&2
+
+# Ensure nonce is in sync
 if [ "$ENVIRONMENT" == "devnet" ]; then
-    log "Setting up AVS Task Mailbox configuration..."
-    PRIVATE_KEY_AVS="${PRIVATE_KEY_AVS}" make setup-avs-task-mailbox-config RPC_URL="${L2_RPC_URL}" ENVIRONMENT="${ENVIRONMENT}" EXECUTOR_OPERATOR_SET_ID=${EXECUTOR_OPERATOR_SET_ID} TASK_SLA=${TASK_SLA} CURVE_TYPE=2 CONTEXT="${CONTEXT}" >&2
     # Sync nonce and sleep to prevent nonce conflicts
     sync_nonce_and_sleep "${PRIVATE_KEY_AVS}" "${L2_RPC_URL}" "AVS" 1
+else
+    # Sleep for a block on other networks
+    sleep 12
 fi
 
 # Step 4: Deploy custom contracts


### PR DESCRIPTION
Configure taskMailbox for executor operatorSet on L2 deployment, regardless of context.