### PR TITLE
fix: typo in upgrade script

### DIFF
--- a/.devkit/scripts/upgrade
+++ b/.devkit/scripts/upgrade
@@ -39,7 +39,7 @@ if [[ ! -d "$originalProjectDir/.devkit/contracts/.git" ]]; then
     log ".devkit/contracts is still a git submodule, removing"
 
     log "running submodule deinit.."
-    git submodule deinit -f .devit/contracts || true
+    git submodule deinit -f .devkit/contracts || true
 
     log "removing submodule .devkit/contracts from git config.."
     git rm -rf .devkit/contracts || true

--- a/.devkit/scripts/upgrade
+++ b/.devkit/scripts/upgrade
@@ -105,6 +105,12 @@ git config -f .gitmodules --get-regexp '^submodule\.' | grep '\.path ' | while r
         git submodule add "$url" "$path"
     fi
 done
+
+# Remove the orphaned submodule at contracts/lib/forge-std
+git submodule deinit -f contracts/lib/forge-std || true
+git rm -f contracts/lib/forge-std || true
+rm -rf .git/modules/contracts/lib/forge-std
+
 log "Updating submodules recursively..."
 git submodule update --init --recursive
 


### PR DESCRIPTION
This PR fixes a typo in the deinit command to correctly deinit devkit submodules, and makes sure we're removing remnants of `contracts/lib/forge-std`