### PR TITLE
fix: template fixes for eigenruntime creation and use by hgctl

### DIFF
--- a/.hourglass/context/devnet.yaml
+++ b/.hourglass/context/devnet.yaml
@@ -11,16 +11,16 @@ aggregator:
   operators:
     - address: "0x90F79bf6EB2c4f870365E785982E1f101E93b906"
       socket: "aggregator:9000"
-  digest: "sha256:070a39857503d50e20b7227ea9481cf03f483d2d5026d03e6b217e04872c18e8"
-  registry: "public.ecr.aws/z6g0f8n7"
+  digest: "sha256:0bea25bc546c79a0b4ba083eeb0956053df2d98216e934bc3b797dbe5c16add6"
+  registry: "public.ecr.aws/z6g0f8n7/eigenlayer-hourglass"
 
 executor:
   operatorSetId: 1
   operators:
     - address: "0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65"
       socket: "executor:9090"
-  digest: "sha256:070a39857503d50e20b7227ea9481cf03f483d2d5026d03e6b217e04872c18e8"
-  registry: "public.ecr.aws/z6g0f8n7"
+  digest: "sha256:0bea25bc546c79a0b4ba083eeb0956053df2d98216e934bc3b797dbe5c16add6"
+  registry: "public.ecr.aws/z6g0f8n7/eigenlayer-hourglass"
 
 mailbox:
   taskSla: 60

--- a/.hourglass/spec/aggregator-runtime-template.yaml
+++ b/.hourglass/spec/aggregator-runtime-template.yaml
@@ -1,5 +1,5 @@
 {{- $values := (datasource "values") -}}
-apiVersion: eigenruntime.io/v1
+apiVersion: eigenruntime.io/v1alpha1
 kind: Hourglass
 name: {{ $values.project.name }}
 version: {{ $values.project.version }}
@@ -8,9 +8,10 @@ spec:
     registry: {{ $values.aggregator.image.registry }}
     digest: {{ $values.aggregator.image.digest }}
     env:
-    {{- range $k, $v := $values.aggregator.env }}
-      - name: {{ $k }}
-        value: "{{ $v }}"
+    {{- range $env := $values.aggregator.env }}
+    - name: {{ $env.name }}
+      type: {{ $env.type }}
+      required: {{ $env.required }}
     {{- end }}
     resources:
       tee_enabled: {{ $values.aggregator.resources.tee_enabled }}

--- a/.hourglass/spec/defaults.yaml
+++ b/.hourglass/spec/defaults.yaml
@@ -8,7 +8,43 @@ aggregator:
     registry: "{{ (datasource "context").AGGREGATOR_REGISTRY }}"
     digest: "{{ (datasource "context").AGGREGATOR_DIGEST }}"
   env:
-    LOG_LEVEL: "info"
+    - name: "OPERATOR_ADDRESS"
+      type: "plain"
+      required: true
+    - name: "OPERATOR_PRIVATE_KEY"
+      type: "plain"
+      required: true
+    - name: "KEYSTORE_PASSWORD"
+      type: "plain"
+      required: true
+    - name: "L1_RPC_URL"
+      type: "plain"
+      required: true
+    - name: "L1_CHAIN_ID"
+      type: "plain"
+      required: true
+    - name: "L2_RPC_URL"
+      type: "plain"
+      required: true
+    - name: "L2_CHAIN_ID"
+      type: "plain"
+      required: false
+   # Optional variables
+    - name: "L1_NETWORK_NAME"
+      type: "plain"
+      required: false
+    - name: "L1_NETWORK"
+      type: "plain"
+      required: false
+    - name: "L2_NETWORK_NAME"
+      type: "plain"
+      required: false
+    - name: "L2_NETWORK"
+      type: "plain"
+      required: false
+    - name: "DEBUG"
+      type: "plain"
+      required: false
   resources:
     tee_enabled: false
 
@@ -18,7 +54,34 @@ executor:
     registry: "{{ (datasource "context").EXECUTOR_REGISTRY }}"
     digest: "{{ (datasource "context").EXECUTOR_DIGEST }}"
   env:
-    LOG_LEVEL: "info"
+    - name: "OPERATOR_ADDRESS"
+      type: "plain"
+      required: true
+    - name: "OPERATOR_PRIVATE_KEY"
+      type: "plain"
+      required: true
+    - name: "KEYSTORE_PASSWORD"
+      type: "plain"
+      required: true
+    - name: "L1_RPC_URL"
+      type: "plain"
+      required: true
+    - name: "L1_CHAIN_ID"
+      type: "plain"
+      required: true
+    # Optional variables
+    - name: "EXECUTOR_SERVICE_PORT"
+      type: "plain"
+      required: false
+    - name: "EXECUTOR_MGMT_PORT"
+      type: "plain"
+      required: false
+    - name: "PERFORMER_NETWORK_NAME"
+      type: "plain"
+      required: false
+    - name: "DEBUG"
+      type: "plain"
+      required: false
   resources:
     tee_enabled: false
 
@@ -27,6 +90,5 @@ performer:
     registry: "{{ (datasource "context").PERFORMER_REGISTRY }}"
     digest: "{{ (datasource "context").PERFORMER_DIGEST }}"
   env:
-    LOG_LEVEL: "info"
   resources:
-    tee_enabled: false 
+    tee_enabled: false

--- a/.hourglass/spec/executor-runtime-template.yaml
+++ b/.hourglass/spec/executor-runtime-template.yaml
@@ -1,5 +1,5 @@
 {{- $values := (datasource "values") -}}
-apiVersion: eigenruntime.io/v1
+apiVersion: eigenruntime.io/v1alpha1
 kind: Hourglass
 name: {{ $values.project.name }}
 version: {{ $values.project.version }}
@@ -7,22 +7,22 @@ spec:
   executor:
     registry: {{ $values.executor.image.registry }}
     digest: {{ $values.executor.image.digest }}
-    command: ["executor", "run"]
     env:
-    {{- range $k, $v := $values.executor.env }}
-      - name: {{ $k }}
-        value: "{{ $v }}"
+    {{- range $env := $values.executor.env }}
+    - name: {{ $env.name }}
+      type: {{ $env.type }}
+      required: {{ $env.required }}
     {{- end }}
     resources:
       tee_enabled: {{ $values.executor.resources.tee_enabled }}
   performer:
     registry: {{ $values.performer.image.registry }}
     digest: {{ $values.performer.image.digest }}
-    command: ["performer", "run"]
     env:
-    {{- range $k, $v := $values.performer.env }}
-      - name: {{ $k }}
-        value: "{{ $v }}"
+    {{- range $env := $values.performer.env }}
+    - name: {{ $env.name }}
+      type: {{ $env.type }}
+      required: {{ $env.required }}
     {{- end }}
     resources:
       tee_enabled: {{ $values.performer.resources.tee_enabled }}

--- a/specs/runtime/devnet.yaml
+++ b/specs/runtime/devnet.yaml
@@ -1,18 +1,18 @@
 # devnet environment overrides
 aggregator:
   env:
-    LOG_LEVEL: "info"
+    -  name: "EXAMPLE_ENV"
+       type: plain
+       required: false
   resources:
     tee_enabled: false
 
 executor:
   env:
-    LOG_LEVEL: "info"
   resources:
     tee_enabled: false
 
 performer:
   env:
-    LOG_LEVEL: "info"
   resources:
     tee_enabled: false

--- a/specs/runtime/mainnet.yaml
+++ b/specs/runtime/mainnet.yaml
@@ -1,18 +1,18 @@
 # mainnet environment overrides
 aggregator:
   env:
-    LOG_LEVEL: "info"
+    -  name: "EXAMPLE_ENV"
+       type: plain
+       required: false
   resources:
     tee_enabled: false
 
 executor:
   env:
-    LOG_LEVEL: "info"
   resources:
     tee_enabled: false
 
 performer:
   env:
-    LOG_LEVEL: "info"
   resources:
     tee_enabled: false

--- a/specs/runtime/testnet.yaml
+++ b/specs/runtime/testnet.yaml
@@ -1,18 +1,18 @@
 # testnet environment overrides
 aggregator:
   env:
-    LOG_LEVEL: "info"
+    -  name: "EXAMPLE_ENV"
+       type: plain
+       required: false
   resources:
     tee_enabled: false
 
 executor:
   env:
-    LOG_LEVEL: "info"
   resources:
     tee_enabled: false
 
 performer:
   env:
-    LOG_LEVEL: "info"
   resources:
     tee_enabled: false


### PR DESCRIPTION
Updating the hourglass template to point to the latest component binaries. Also updating the EigenRuntime to use the full env spec definition.