### PR TITLE
feat: add aggregator operators to allowlist

### DIFF
--- a/.devkit/contracts/Makefile
+++ b/.devkit/contracts/Makefile
@@ -15,7 +15,7 @@ deploy-avs-l1-contracts:
 	forge script script/deploy/DeployAVSL1Contracts.s.sol \
 		--rpc-url $(RPC_URL) \
 		--broadcast \
-		--sig "run(string, address, address, address, address, uint32, uint32)" $(ENVIRONMENT) $(AVS_ADDRESS) $(ALLOCATION_MANAGER_ADDRESS) $(KEY_REGISTRAR_ADDRESS) $(PERMISSION_CONTROLLER_ADDRESS) $(AGGREGATOR_OPERATOR_SET_ID) $(EXECUTOR_OPERATOR_SET_ID) \
+		--sig "run(string, address, address, address, address, uint32, uint32, address[])" $(ENVIRONMENT) $(AVS_ADDRESS) $(ALLOCATION_MANAGER_ADDRESS) $(KEY_REGISTRAR_ADDRESS) $(PERMISSION_CONTROLLER_ADDRESS) $(AGGREGATOR_OPERATOR_SET_ID) $(EXECUTOR_OPERATOR_SET_ID) $(AGGREGATOR_OPERATORS) \
 		--slow \
 		-vvvv
 

--- a/.devkit/contracts/script/call/CreateTask.s.sol
+++ b/.devkit/contracts/script/call/CreateTask.s.sol
@@ -9,7 +9,13 @@ import {ITaskMailbox, ITaskMailboxTypes} from "@eigenlayer-contracts/src/contrac
 contract CreateTask is Script {
     using stdJson for string;
 
-    function run(string memory environment, address taskMailbox, address avs, uint32 executorOperatorSetId, bytes memory payload) public {
+    function run(
+        string memory environment,
+        address taskMailbox,
+        address avs,
+        uint32 executorOperatorSetId,
+        bytes memory payload
+    ) public {
         // TaskMailbox address from args
         console.log("Task Mailbox:", taskMailbox);
 

--- a/.devkit/contracts/script/deploy/DeployAVSL1Contracts.s.sol
+++ b/.devkit/contracts/script/deploy/DeployAVSL1Contracts.s.sol
@@ -46,7 +46,9 @@ contract DeployAVSL1Contracts is Script {
 
         // Deploy implementation
         TaskAVSRegistrar taskAVSRegistrarImpl = new TaskAVSRegistrar(
-            IAllocationManager(allocationManager), IKeyRegistrar(keyRegistrar), IPermissionController(permissionController)
+            IAllocationManager(allocationManager),
+            IKeyRegistrar(keyRegistrar),
+            IPermissionController(permissionController)
         );
         console.log("TaskAVSRegistrar implementation deployed to:", address(taskAVSRegistrarImpl));
 
@@ -54,14 +56,18 @@ contract DeployAVSL1Contracts is Script {
         TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy(
             address(taskAVSRegistrarImpl),
             address(proxyAdmin),
-            abi.encodeWithSelector(TaskAVSRegistrar.initialize.selector, avs, vm.addr(deployerPrivateKey), initialConfig)
+            abi.encodeWithSelector(
+                TaskAVSRegistrar.initialize.selector, avs, vm.addr(deployerPrivateKey), initialConfig
+            )
         );
         console.log("TaskAVSRegistrar proxy deployed to:", address(proxy));
 
         // Whitelist operators
         OperatorSet memory aggregatorOperatorSet = OperatorSet({avs: avs, id: aggregatorOperatorSetId});
         for (uint256 i = 0; i < aggregatorWhitelistedOperators.length; i++) {
-            TaskAVSRegistrar(address(proxy)).addOperatorToAllowlist(aggregatorOperatorSet, aggregatorWhitelistedOperators[i]);
+            TaskAVSRegistrar(address(proxy)).addOperatorToAllowlist(
+                aggregatorOperatorSet, aggregatorWhitelistedOperators[i]
+            );
         }
 
         // Transfer ownership of the proxy to the avs
@@ -76,7 +82,12 @@ contract DeployAVSL1Contracts is Script {
         _writeOutputToJson(environment, address(proxy), address(taskAVSRegistrarImpl), address(proxyAdmin));
     }
 
-    function _writeOutputToJson(string memory environment, address taskAVSRegistrarProxy, address taskAVSRegistrarImpl, address proxyAdmin) internal {
+    function _writeOutputToJson(
+        string memory environment,
+        address taskAVSRegistrarProxy,
+        address taskAVSRegistrarImpl,
+        address proxyAdmin
+    ) internal {
         // Add the addresses object
         string memory addresses = "addresses";
         vm.serializeAddress(addresses, "taskAVSRegistrar", taskAVSRegistrarProxy);

--- a/.devkit/contracts/script/setup/SetupAVSTaskMailboxConfig.s.sol
+++ b/.devkit/contracts/script/setup/SetupAVSTaskMailboxConfig.s.sol
@@ -25,7 +25,13 @@ contract SetupAVSTaskMailboxConfig is Script {
         IAVSTaskHook taskHook;
     }
 
-    function run(string memory environment, uint32 executorOperatorSetId, uint96 taskSLA, uint8 curveType, string memory _context) public {
+    function run(
+        string memory environment,
+        uint32 executorOperatorSetId,
+        uint96 taskSLA,
+        uint8 curveType,
+        string memory _context
+    ) public {
         // Read the context
         Context memory context = _readContext(environment, _context);
 
@@ -64,17 +70,18 @@ contract SetupAVSTaskMailboxConfig is Script {
         vm.stopBroadcast();
     }
 
-    function _readContext(
-        string memory environment,
-        string memory _context
-    ) internal view returns (Context memory) {
+    function _readContext(string memory environment, string memory _context) internal view returns (Context memory) {
         // Parse the context
         Context memory context;
         context.avs = stdJson.readAddress(_context, ".context.avs.address");
         context.avsPrivateKey = uint256(stdJson.readBytes32(_context, ".context.avs.avs_private_key"));
         context.deployerPrivateKey = uint256(stdJson.readBytes32(_context, ".context.deployer_private_key"));
-        context.certificateVerifier = IBN254CertificateVerifier(stdJson.readAddress(_context, ".context.eigenlayer.l2.bn254_certificate_verifier"));
-        context.ecdsaCertificateVerifier = IECDSACertificateVerifier(stdJson.readAddress(_context, ".context.eigenlayer.l2.ecdsa_certificate_verifier"));
+        context.certificateVerifier = IBN254CertificateVerifier(
+            stdJson.readAddress(_context, ".context.eigenlayer.l2.bn254_certificate_verifier")
+        );
+        context.ecdsaCertificateVerifier = IECDSACertificateVerifier(
+            stdJson.readAddress(_context, ".context.eigenlayer.l2.ecdsa_certificate_verifier")
+        );
         context.taskMailbox = ITaskMailbox(_readHourglassConfigAddress(environment, "taskMailbox"));
         context.taskHook = IAVSTaskHook(_readAVSL2ConfigAddress(environment, "avsTaskHook"));
 

--- a/.devkit/scripts/deployL1Contracts
+++ b/.devkit/scripts/deployL1Contracts
@@ -136,6 +136,11 @@ fi
 AGGREGATOR_OPERATOR_SET_ID=$(yq -r '.aggregator.operatorSetId' "$ENVIRONMENT_YAML_FILE")
 EXECUTOR_OPERATOR_SET_ID=$(yq -r '.executor.operatorSetId' "$ENVIRONMENT_YAML_FILE")
 
+# Extract aggregator operators addresses as a comma-separated list with brackets for Forge
+AGGREGATOR_OPERATORS_RAW=$(yq -r '.aggregator.operators[].address' "$ENVIRONMENT_YAML_FILE" | paste -sd "," -)
+# Format for Forge: [addr1,addr2,addr3]
+AGGREGATOR_OPERATORS="[${AGGREGATOR_OPERATORS_RAW}]"
+
 # Validate YAML values
 if [ "$AGGREGATOR_OPERATOR_SET_ID" == "null" ]; then
     log "Error: Missing aggregator.operatorSetId in ${ENVIRONMENT_YAML_FILE}"
@@ -144,6 +149,12 @@ fi
 
 if [ "$EXECUTOR_OPERATOR_SET_ID" == "null" ]; then
     log "Error: Missing executor.operatorSetId in ${ENVIRONMENT_YAML_FILE}"
+    exit 1
+fi
+
+# Validate aggregator operators
+if [ -z "$AGGREGATOR_OPERATORS_RAW" ] || [ "$AGGREGATOR_OPERATORS_RAW" == "null" ]; then
+    log "Error: Missing or empty aggregator.operators in ${ENVIRONMENT_YAML_FILE}"
     exit 1
 fi
 
@@ -172,7 +183,7 @@ mkdir -p script/$ENVIRONMENT/output
 
 # Deploy AVS L1 contracts
 log "Deploying AVS L1 contracts..."
-PRIVATE_KEY_DEPLOYER="${PRIVATE_KEY_DEPLOYER}" make deploy-avs-l1-contracts RPC_URL="${L1_RPC_URL}" ENVIRONMENT="${ENVIRONMENT}" AVS_ADDRESS="${AVS_ADDRESS}" ALLOCATION_MANAGER_ADDRESS="${ALLOCATION_MANAGER_ADDRESS}" KEY_REGISTRAR_ADDRESS="${KEY_REGISTRAR_ADDRESS}" PERMISSION_CONTROLLER_ADDRESS="${PERMISSION_CONTROLLER_ADDRESS}" AGGREGATOR_OPERATOR_SET_ID="${AGGREGATOR_OPERATOR_SET_ID}" EXECUTOR_OPERATOR_SET_ID="${EXECUTOR_OPERATOR_SET_ID}" >&2
+PRIVATE_KEY_DEPLOYER="${PRIVATE_KEY_DEPLOYER}" make deploy-avs-l1-contracts RPC_URL="${L1_RPC_URL}" ENVIRONMENT="${ENVIRONMENT}" AVS_ADDRESS="${AVS_ADDRESS}" ALLOCATION_MANAGER_ADDRESS="${ALLOCATION_MANAGER_ADDRESS}" KEY_REGISTRAR_ADDRESS="${KEY_REGISTRAR_ADDRESS}" PERMISSION_CONTROLLER_ADDRESS="${PERMISSION_CONTROLLER_ADDRESS}" AGGREGATOR_OPERATOR_SET_ID="${AGGREGATOR_OPERATOR_SET_ID}" EXECUTOR_OPERATOR_SET_ID="${EXECUTOR_OPERATOR_SET_ID}" AGGREGATOR_OPERATORS="${AGGREGATOR_OPERATORS}" >&2
 
 log "L1 contract deployment completed successfully."
 


### PR DESCRIPTION
# Motivation
As part of the SigmaPrime findings, we need to have an allowlist for the Aggregator operator set in the TaskAVSRegistrarBase (since it's a trusted entity).

# Modifications:
* Bumped up the `eigenlayer-middleware` libs dependency to pull in the latest audit fix.
* Updated `DeployAVSL1Contracts.s.sol` to take in the aggregatorOperators list. It adds them to the allowlist as part of the deployment process
* Updated the Makefile and deployL1Contracts devkit scripts to extract the aggregatorOperators list and pass that to `DeployAVSL1Contracts.s.sol`
* Ran forge fmt
