### PR TITLE
fix: install ca-certificates on performer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,8 @@ FROM debian:stable-slim
 
 COPY --from=build /build/bin/performer /usr/local/bin/performer
 
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
 CMD ["/usr/local/bin/performer"]


### PR DESCRIPTION
This PR installs ca-certificates to the performer image to ensure trusted root CAs are available for TLS handshakes inside the performer binary