### PR TITLE
chore: update core bindings

### DIFF
--- a/.devkit/contracts/foundry.lock
+++ b/.devkit/contracts/foundry.lock
@@ -1,0 +1,8 @@
+{
+  ".devkit/contracts/lib/eigenlayer-middleware": {
+    "rev": "8f8cb97b3097dc5adbcba2db4b80073e4df3b9f8"
+  },
+  ".devkit/contracts/lib/forge-std": {
+    "rev": "77041d2ce690e692d6e03cc812b57d1ddaa4d505"
+  }
+}


### PR DESCRIPTION
Pulling the latest middleware contract changes which includes the update core contract bindings. This has the change in bindings for the TaskMailbox contract.